### PR TITLE
Fix for bad data in the dashboard

### DIFF
--- a/volkswagencarnet.py
+++ b/volkswagencarnet.py
@@ -507,7 +507,7 @@ class Vehicle(object):
     @property
     def distance(self):
         if self.distance_supported:
-            value = self.data.get('vehicle-details',{}).get('distanceCovered', None).replace('.', '').replace(',','')
+            value = self.data.get('vehicle-details',{}).get('distanceCovered', None).replace('.', '').replace(',','').replace('--', '')
             if value:
                 return int(value)
 


### PR DESCRIPTION
This fixes an issue that prevents [homeassistant-volkswagencarnet](https://github.com/robinostlund/homeassistant-volkswagencarnet/issues/42) from starting when the dashboard has "bad" or unknown data.

As seen in this screenshot:

<img width="531" alt="65971190-17e31300-e468-11e9-87ed-503616f3e9ab" src="https://user-images.githubusercontent.com/1990/65986162-9f8a4b00-e483-11e9-9670-2777b6a5f4ff.png">
