### PR TITLE
Add support for combustion engine heating

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,28 @@
 ### IN DEVELOPMENT
-Volkswagen Carnet
-============================================================
+
+# Volkswagen Carnet
+
 Retrieve statistics about your Volkswagen from the Volkswagen Carnet online service
 
 No licence, public domain, no guarantees, feel free to use for anything. Please contribute improvements/bugfixes etc.
 
-Python Client can be found here: 
+Python Client can be found here:
 
 https://github.com/robinostlund/volkswagencarnet-client
 
-Homeassistant Platform can be found here: 
+Homeassistant Platform can be found here:
 
 https://github.com/robinostlund/homeassistant-volkswagencarnet
 
+## Installation
 
-Installation
---------------
 ```sh
 [venv-python3] user@localhost:~
 $ pip install volkswagencarnet
 ```
 
 ### Example
+
 ```python
 #!/usr/bin/env python3
 import sys
@@ -33,7 +34,7 @@ vw._login()
 if not vw.logged_in:
     print('Could not login to carnet')
     sys.exit(1)
-    
+
 # get vehicles from carnet
 vw.update()
 
@@ -58,6 +59,7 @@ for vehicle in vehicles:
     print(' Charging time left: %s' % vehicle.charging_time_left_supported)
     print(' Door Locked: %s' % vehicle.door_locked_supported)
     print(' Electric Range: %s' % vehicle.electric_range_supported)
+    print(' Combustion Engine Heating: %s' % vehicle.combustion_engine_heating_supported)
 
     print('Vehicle information:')
     print(' Distance: %s' % vehicle.distance)
@@ -73,6 +75,7 @@ for vehicle in vehicles:
     print(' Is Window Heater On: %s' % vehicle.is_window_heater_on)
     print(' Is Charging On: %s' % vehicle.is_charging_on)
     print(' Is Request in progress: %s' % vehicle.is_request_in_progress)
+  
     # and more
 
 # action: start climatisation

--- a/dashboard.py
+++ b/dashboard.py
@@ -348,6 +348,27 @@ class WindowHeater(Switch):
     def assumed_state(self):
         return False
 
+class RemoteAccessHeating(Switch):
+    def __init__(self):
+        super().__init__(attr="remote_access_heating", name="Remote Access Heating", icon="mdi:radiator")
+
+    def configurate(self, **config):
+        self.spin = config.get('spin', '')
+
+    @property
+    def state(self):
+        return self.vehicle.remote_access_heating
+
+    def turn_on(self):
+        self.vehicle.start_remote_access_heating(self.spin)
+
+    def turn_off(self):
+        self.vehicle.stop_remote_access_heating()
+
+    @property
+    def assumed_state(self):
+        return False
+
 def create_instruments():
     return [
         Position(),
@@ -357,6 +378,7 @@ def create_instruments():
         ClimatisationClimate(),
         Charging(),
         WindowHeater(),
+        RemoteAccessHeating(),
         Sensor(
             attr="distance",
             name="Odometer",

--- a/dashboard.py
+++ b/dashboard.py
@@ -348,22 +348,22 @@ class WindowHeater(Switch):
     def assumed_state(self):
         return False
 
-class RemoteAccessHeating(Switch):
+class CombustionEngineHeating(Switch):
     def __init__(self):
-        super().__init__(attr="remote_access_heating", name="Remote Access Heating", icon="mdi:radiator")
+        super().__init__(attr="combustion_engine_heating", name="Combustion Engine Heating", icon="mdi:radiator")
 
     def configurate(self, **config):
         self.spin = config.get('spin', '')
 
     @property
     def state(self):
-        return self.vehicle.remote_access_heating
+        return self.vehicle.combustion_engine_heating
 
     def turn_on(self):
-        self.vehicle.start_remote_access_heating(self.spin)
+        self.vehicle.start_combustion_engine_heating(self.spin)
 
     def turn_off(self):
-        self.vehicle.stop_remote_access_heating()
+        self.vehicle.stop_combustion_engine_heating()
 
     @property
     def assumed_state(self):
@@ -378,7 +378,7 @@ def create_instruments():
         ClimatisationClimate(),
         Charging(),
         WindowHeater(),
-        RemoteAccessHeating(),
+        CombustionEngineHeating(),
         Sensor(
             attr="distance",
             name="Odometer",

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,15 @@
 from setuptools import setup
 
+# Temporary bumping version to get this to work on my fork.
+# Should be fixed, once/if this get merged to Robins repo.
 setup(
-    name = 'volkswagencarnet',
-    version = '4.0.29',
-    description = 'Communicate with Volkswagen Carnet',
-    author = 'Robin Ostlund',
-    author_email = 'me@robinostlund.name',
-    url = 'https://github.com/robinostlund/volkswagencarnet',
-    download_url = 'https://github.com/robinostlund/volkswagencarnet/archive/4.0.29.tar.gz',
+    name='volkswagencarnet',
+    version='4.1.1',
+    description='Communicate with Volkswagen Carnet',
+    author='Robin Ostlund',
+    author_email='me@robinostlund.name',
+    url='https://github.com/robinostlund/volkswagencarnet',
+    download_url='https://github.com/robinostlund/volkswagencarnet/archive/4.0.29.tar.gz',
     py_modules=[
         "volkswagencarnet",
         "dashboard",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # Should be fixed, once/if this get merged to Robins repo.
 setup(
     name='volkswagencarnet',
-    version='4.1.1',
+    version='4.1.2',
     description='Communicate with Volkswagen Carnet',
     author='Robin Ostlund',
     author_email='me@robinostlund.name',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # Should be fixed, once/if this get merged to Robins repo.
 setup(
     name='volkswagencarnet',
-    version='4.1.2',
+    version='4.1.3',
     description='Communicate with Volkswagen Carnet',
     author='Robin Ostlund',
     author_email='me@robinostlund.name',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # Should be fixed, once/if this get merged to Robins repo.
 setup(
     name='volkswagencarnet',
-    version='4.1.3',
+    version='4.1.4',
     description='Communicate with Volkswagen Carnet',
     author='Robin Ostlund',
     author_email='me@robinostlund.name',

--- a/utilities.py
+++ b/utilities.py
@@ -1,0 +1,78 @@
+from datetime import date, datetime
+from base64 import b64encode
+from string import ascii_letters as letters, digits
+from sys import argv
+from os import environ as env
+from os.path import join, dirname, expanduser
+from itertools import product
+import json
+import logging
+import re
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def find_path(src, path):
+    """Simple navigation of a hierarchical dict structure using XPATH-like syntax.
+
+    >>> find_path(dict(a=1), 'a')
+    1
+
+    >>> find_path(dict(a=1), '')
+    {'a': 1}
+
+    >>> find_path(dict(a=None), 'a')
+
+
+    >>> find_path(dict(a=1), 'b')
+    Traceback (most recent call last):
+    ...
+    KeyError: 'b'
+
+    >>> find_path(dict(a=dict(b=1)), 'a.b')
+    1
+
+    >>> find_path(dict(a=dict(b=1)), 'a')
+    {'b': 1}
+
+    >>> find_path(dict(a=dict(b=1)), 'a.c')
+    Traceback (most recent call last):
+    ...
+    KeyError: 'c'
+
+    """
+    if not path:
+        return src
+    if isinstance(path, str):
+        path = path.split(".")
+    return find_path(src[path[0]], path[1:])
+
+
+def is_valid_path(src, path):
+    """
+    >>> is_valid_path(dict(a=1), 'a')
+    True
+
+    >>> is_valid_path(dict(a=1), '')
+    True
+
+    >>> is_valid_path(dict(a=1), None)
+    True
+
+    >>> is_valid_path(dict(a=1), 'b')
+    False
+    """
+    try:
+        find_path(src, path)
+        return True
+    except KeyError:
+        return False
+
+
+def camel2slug(s):
+    """Convert camelCase to camel_case.
+
+    >>> camel2slug('fooBar')
+    'foo_bar'
+    """
+    return re.sub("([A-Z])", "_\\1", s).lower().lstrip("_")

--- a/volkswagencarnet.py
+++ b/volkswagencarnet.py
@@ -18,7 +18,7 @@ from utilities import find_path, is_valid_path
 
 version_info >= (3, 0) or exit('Python 3 required')
 
-__version__ = '4.1.1'
+__version__ = '4.1.2'
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/volkswagencarnet.py
+++ b/volkswagencarnet.py
@@ -18,7 +18,7 @@ from utilities import find_path, is_valid_path
 
 version_info >= (3, 0) or exit('Python 3 required')
 
-__version__ = '4.1.3'
+__version__ = '4.1.4'
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,6 +26,7 @@ TIMEOUT = timedelta(seconds=30)
 
 # disable request ssl verification due to vw having issues with ca.
 disable_warnings()
+
 
 def _obj_parser(obj):
     """Parse datetime (only Python3 because of timezone)."""
@@ -36,6 +37,7 @@ def _obj_parser(obj):
             pass
     return obj
 
+
 class TimeoutRequestsSession(Session):
     def request(self, *args, **kwargs):
         if kwargs.get('timeout') is None:
@@ -44,14 +46,18 @@ class TimeoutRequestsSession(Session):
         kwargs['verify'] = False
         return super(TimeoutRequestsSession, self).request(*args, **kwargs)
 
+
 class Connection(object):
     """ Connection to Volkswagen Carnet """
-    def __init__(self, username, password, guest_lang = 'en'):
+
+    def __init__(self, username, password, guest_lang='en'):
         """ Initialize """
         self._session = TimeoutRequestsSession()
-        self._session_headers = { 'Accept': 'application/json, text/plain, */*', 'Content-Type': 'application/json;charset=UTF-8', 'User-Agent': 'Mozilla/5.0 (Linux; Android 6.0.1; D5803 Build/23.5.A.1.291; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.111 Mobile Safari/537.36' }
+        self._session_headers = {'Accept': 'application/json, text/plain, */*', 'Content-Type': 'application/json;charset=UTF-8',
+                                 'User-Agent': 'Mozilla/5.0 (Linux; Android 6.0.1; D5803 Build/23.5.A.1.291; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.111 Mobile Safari/537.36'}
         self._session_base = 'https://www.portal.volkswagen-we.com/'
-        self._session_auth_headers = {'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3', 'Content-Type': 'application/x-www-form-urlencoded', 'User-Agent': 'Mozilla/5.0 (Linux; Android 6.0.1; D5803 Build/23.5.A.1.291; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.111 Mobile Safari/537.36'}
+        self._session_auth_headers = {'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3', 'Content-Type': 'application/x-www-form-urlencoded',
+                                      'User-Agent': 'Mozilla/5.0 (Linux; Android 6.0.1; D5803 Build/23.5.A.1.291; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.111 Mobile Safari/537.36'}
         self._session_auth_base = 'https://identity.vwgroup.io'
         self._session_guest_language_id = guest_lang
 
@@ -69,8 +75,10 @@ class Connection(object):
     def _login(self):
         """ Reset session in case we would like to login again """
         self._session = TimeoutRequestsSession()
-        self._session_headers = { 'Accept': 'application/json, text/plain, */*', 'Content-Type': 'application/json;charset=UTF-8', 'User-Agent': 'Mozilla/5.0 (Linux; Android 6.0.1; D5803 Build/23.5.A.1.291; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.111 Mobile Safari/537.36' }
-        self._session_auth_headers = {'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3', 'Content-Type': 'application/x-www-form-urlencoded', 'User-Agent': 'Mozilla/5.0 (Linux; Android 6.0.1; D5803 Build/23.5.A.1.291; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.111 Mobile Safari/537.36'}
+        self._session_headers = {'Accept': 'application/json, text/plain, */*', 'Content-Type': 'application/json;charset=UTF-8',
+                                 'User-Agent': 'Mozilla/5.0 (Linux; Android 6.0.1; D5803 Build/23.5.A.1.291; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.111 Mobile Safari/537.36'}
+        self._session_auth_headers = {'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3', 'Content-Type': 'application/x-www-form-urlencoded',
+                                      'User-Agent': 'Mozilla/5.0 (Linux; Android 6.0.1; D5803 Build/23.5.A.1.291; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.111 Mobile Safari/537.36'}
 
         def extract_csrf(req):
             return re.compile('<meta name="_csrf" content="([^"]*)"/>').search(req.text).group(1)
@@ -80,14 +88,16 @@ class Connection(object):
 
         try:
             # Request landing page and get CSFR:
-            req = self._session.get(self._session_base + '/portal/en_GB/web/guest/home')
+            req = self._session.get(
+                self._session_base + '/portal/en_GB/web/guest/home')
             if req.status_code != 200:
                 return ""
             csrf = extract_csrf(req)
 
             # Request login page and get CSRF
             self._session_auth_headers['Referer'] = self._session_base + 'portal'
-            req = self._session.post(self._session_base + 'portal/web/guest/home/-/csrftokenhandling/get-login-url', headers = self._session_auth_headers)
+            req = self._session.post(
+                self._session_base + 'portal/web/guest/home/-/csrftokenhandling/get-login-url', headers=self._session_auth_headers)
             if req.status_code != 200:
                 return ""
 
@@ -95,13 +105,15 @@ class Connection(object):
             lg_url = response_data.get("loginURL").get("path")
 
             # no redirect so we can get values we look for
-            req = self._session.get(lg_url, allow_redirects=False, headers = self._session_auth_headers)
+            req = self._session.get(
+                lg_url, allow_redirects=False, headers=self._session_auth_headers)
             if req.status_code != 302:
                 return ""
-            ref_url_1= req.headers.get("location")
+            ref_url_1 = req.headers.get("location")
 
             # now get actual login page and get session id and ViewState
-            req = self._session.get(ref_url_1, headers = self._session_auth_headers)
+            req = self._session.get(
+                ref_url_1, headers=self._session_auth_headers)
             if req.status_code != 200:
                 return ""
 
@@ -110,7 +122,8 @@ class Connection(object):
             login_csrf = bs.select_one('input[name=_csrf]')['value']
             login_token = bs.select_one('input[name=relayState]')['value']
             login_hmac = bs.select_one('input[name=hmac]')['value']
-            login_form_action = bs.find('form', id ='emailPasswordForm').get('action')
+            login_form_action = bs.find(
+                'form', id='emailPasswordForm').get('action')
             login_url = self._session_auth_base + login_form_action
 
             # post login
@@ -124,7 +137,8 @@ class Connection(object):
                 '_csrf': login_csrf,
             }
             # post: https://identity.vwgroup.io/signin-service/v1/xxx@apps_vw-dilab_com/login/identifier
-            req = self._session.post(login_url, data = post_data, allow_redirects=False, headers = self._session_auth_headers)
+            req = self._session.post(
+                login_url, data=post_data, allow_redirects=False, headers=self._session_auth_headers)
 
             if req.status_code != 303:
                 return ""
@@ -132,9 +146,9 @@ class Connection(object):
             ref_url_2 = req.headers.get("location")
             auth_relay_url = self._session_auth_base + ref_url_2
 
-
             # get: https://identity.vwgroup.io/signin-service/v1/xxx@apps_vw-dilab_com/login/authenticate?relayState=xxx&email=xxx
-            req = self._session.get(auth_relay_url, allow_redirects=False, headers = self._session_auth_headers)
+            req = self._session.get(
+                auth_relay_url, allow_redirects=False, headers=self._session_auth_headers)
             if req.status_code != 200:
                 return ""
 
@@ -143,7 +157,8 @@ class Connection(object):
             auth_csrf = bs.select_one('input[name=_csrf]')['value']
             auth_token = bs.select_one('input[name=relayState]')['value']
             auth_hmac = bs.select_one('input[name=hmac]')['value']
-            auth_form_action = bs.find('form', id ='credentialsForm').get('action')
+            auth_form_action = bs.find(
+                'form', id='credentialsForm').get('action')
             auth_url = self._session_auth_base + auth_form_action
 
             # post login
@@ -157,26 +172,30 @@ class Connection(object):
                 '_csrf': auth_csrf,
             }
             # post: https://identity.vwgroup.io/signin-service/v1/xxx@apps_vw-dilab_com/login/authenticate
-            req = self._session.post(auth_url, data = post_data, allow_redirects=False, headers = self._session_auth_headers)
+            req = self._session.post(
+                auth_url, data=post_data, allow_redirects=False, headers=self._session_auth_headers)
             if req.status_code != 302:
                 return ""
 
             # get: https://identity.vwgroup.io/oidc/v1/oauth/sso?clientId=xxx@apps_vw-dilab_com&relayState=xxx&userId=xxx&HMAC=xxx
             ref_url_3 = req.headers.get("location")
-            req = self._session.get(ref_url_3, allow_redirects=False, headers = self._session_auth_headers)
+            req = self._session.get(
+                ref_url_3, allow_redirects=False, headers=self._session_auth_headers)
             if req.status_code != 302:
                 return ""
 
             # get: https://identity.vwgroup.io/consent/v1/users/xxx/xxx@apps_vw-dilab_com?scopes=openid%20profile%20birthdate%20nickname%20address%20email%20phone%20cars%20dealers%20mbb&relay_state=xxx&callback=https://identity.vwgroup.io/oidc/v1/oauth/client/callback&hmac=xxx
             ref_url_4 = req.headers.get("location")
-            req = self._session.get(ref_url_4, allow_redirects=False, headers = self._session_auth_headers)
+            req = self._session.get(
+                ref_url_4, allow_redirects=False, headers=self._session_auth_headers)
             if req.status_code != 302:
                 return ""
 
             # get: https://identity.vwgroup.io/oidc/v1/oauth/client/callback/success?user_id=xxx&client_id=xxx@apps_vw-dilab_com&scopes=openid%20profile%20birthdate%20nickname%20address%20email%20phone%20cars%20dealers%20mbb&consentedScopes=openid%20profile%20birthdate%20nickname%20address%20email%20phone%20cars%20dealers%20mbb&relay_state=xxx&hmac=xxx
             ref_url_5 = req.headers.get("location")
             user_id = parse_qs(urlparse(ref_url_5).query).get('user_id')[0]
-            req = self._session.get(ref_url_5, allow_redirects=False, headers = self._session_auth_headers)
+            req = self._session.get(
+                ref_url_5, allow_redirects=False, headers=self._session_auth_headers)
             if req.status_code != 302:
                 return ""
 
@@ -191,21 +210,24 @@ class Connection(object):
                 '_33_WAR_cored5portlet_code': code,
                 '_33_WAR_cored5portlet_landingPageUrl': ''
             }
-            req = self._session.post(self._session_base + urlsplit(ref_url_6).path + '?p_auth=' + state + '&p_p_id=33_WAR_cored5portlet&p_p_lifecycle=1&p_p_state=normal&p_p_mode=view&p_p_col_id=column-1&p_p_col_count=1&_33_WAR_cored5portlet_javax.portlet.action=getLoginStatus', data = post_data, allow_redirects = False, headers = self._session_auth_headers)
+            req = self._session.post(self._session_base + urlsplit(ref_url_6).path + '?p_auth=' + state +
+                                     '&p_p_id=33_WAR_cored5portlet&p_p_lifecycle=1&p_p_state=normal&p_p_mode=view&p_p_col_id=column-1&p_p_col_count=1&_33_WAR_cored5portlet_javax.portlet.action=getLoginStatus', data=post_data, allow_redirects=False, headers=self._session_auth_headers)
             if req.status_code != 302:
                 return ""
 
             # get: https://www.portal.volkswagen-we.com/portal/user/xxx/v_8xxx
             ref_url_7 = req.headers.get("location")
-            req = self._session.get(ref_url_7, allow_redirects=False, headers = self._session_auth_headers)
+            req = self._session.get(
+                ref_url_7, allow_redirects=False, headers=self._session_auth_headers)
             if req.status_code != 200:
-               return ""
+                return ""
 
             # We have a new CSRF
             csrf = extract_csrf(req)
 
             cookie = self._session.cookies.get_dict()
-            self._session_guest_language_id = extract_guest_language_id(cookie.get('GUEST_LANGUAGE_ID', {}))
+            self._session_guest_language_id = extract_guest_language_id(
+                cookie.get('GUEST_LANGUAGE_ID', {}))
 
             # Update headers for requests
             self._session_headers["Referer"] = ref_url_7
@@ -229,7 +251,8 @@ class Connection(object):
             _LOGGER.debug('Received %s', res)
             return res
         except RequestException as error:
-            _LOGGER.warning('Failure when communcating with the server: %s, url: %s', error, url)
+            _LOGGER.warning(
+                'Failure when communcating with the server: %s, url: %s', error, url)
             raise
 
     def _logout(self):
@@ -243,12 +266,13 @@ class Connection(object):
         """Perform a post query to the online service."""
         return self._request(partial(self._session.post, json=data), ref, rel)
 
-    def update(self, reset=False, request_data = True):
+    def update(self, reset=False, request_data=True):
         """Update status."""
         try:
             if self._session_first_update:
                 if not self.validate_login:
-                    _LOGGER.warning('Session expired, creating new login session to carnet.')
+                    _LOGGER.warning(
+                        'Session expired, creating new login session to carnet.')
                     self._login()
             else:
                 self._session_first_update = True
@@ -256,18 +280,22 @@ class Connection(object):
             _LOGGER.debug('Updating vehicle status from carnet')
             if not self._state or reset:
                 _LOGGER.debug('Querying vehicles')
-                owners_verification = self.post('/portal/group/%s/edit-profile/-/profile/get-vehicles-owners-verification' % self._session_guest_language_id)
+                owners_verification = self.post(
+                    '/portal/group/%s/edit-profile/-/profile/get-vehicles-owners-verification' % self._session_guest_language_id)
 
                 # get vehicles
-                loaded_vehicles = self.post('-/mainnavigation/get-fully-loaded-cars')
+                loaded_vehicles = self.post(
+                    '-/mainnavigation/get-fully-loaded-cars')
 
                 # load all not loaded vehicles
                 if loaded_vehicles.get('fullyLoadedVehiclesResponse', {}).get('vehiclesNotFullyLoaded', []):
                     for vehicle in loaded_vehicles.get('fullyLoadedVehiclesResponse').get('vehiclesNotFullyLoaded'):
-                        self.post('-/mainnavigation/load-car-details/%s' % vehicle.get('vin'))
+                        self.post('-/mainnavigation/load-car-details/%s' %
+                                  vehicle.get('vin'))
 
                     # update loaded cars
-                    loaded_vehicles = self.post('-/mainnavigation/get-fully-loaded-cars')
+                    loaded_vehicles = self.post(
+                        '-/mainnavigation/get-fully-loaded-cars')
 
                 # update vehicles
                 if loaded_vehicles.get('fullyLoadedVehiclesResponse', {}).get('completeVehicles', []):
@@ -281,55 +309,66 @@ class Connection(object):
                 try:
                     vehicle_data = self.post('-/vsr/get-vsr', rel)
                     if vehicle_data.get('errorCode', {}) == '0' and vehicle_data.get('vehicleStatusData', {}):
-                        self._state[vin]['vsr'] = vehicle_data.get('vehicleStatusData', {})
+                        self._state[vin]['vsr'] = vehicle_data.get(
+                            'vehicleStatusData', {})
                 except Exception as err:
                     _LOGGER.debug('Could not fetch vsr data: %s' % err)
 
                 # request update of vehicle status data if not in progress
                 if request_data and vehicle_data.get('vehicleStatusData', {}).get('requestStatus', {}) != 'REQUEST_IN_PROGRESS':
-                    update_request = self.post('-/vsr/request-vsr', rel, dummy='data')
+                    update_request = self.post(
+                        '-/vsr/request-vsr', rel, dummy='data')
                     if update_request.get('errorCode') != '0':
                         _LOGGER.error('Failed to request vehicle update')
 
                 if not vehicle['engineTypeCombustian']:
                     # fetch vehicle emanage data
                     try:
-                        vehicle_emanager = self.post('-/emanager/get-emanager', rel)
+                        vehicle_emanager = self.post(
+                            '-/emanager/get-emanager', rel)
                         if vehicle_emanager.get('errorCode', {}) == '0' and vehicle_emanager.get('EManager', {}):
-                            self._state[vin]['emanager'] = vehicle_emanager.get('EManager', {})
+                            self._state[vin]['emanager'] = vehicle_emanager.get(
+                                'EManager', {})
                     except Exception as err:
-                        _LOGGER.debug('Could not fetch emanager data: %s' % err)
+                        _LOGGER.debug(
+                            'Could not fetch emanager data: %s' % err)
 
                 # fetch vehicle location data
                 try:
                     vehicle_location = self.post('-/cf/get-location', rel)
                     if vehicle_location.get('errorCode', {}) == '0' and vehicle_location.get('position', {}):
-                        self._state[vin]['position'] = vehicle_location.get('position', {})
+                        self._state[vin]['position'] = vehicle_location.get(
+                            'position', {})
                 except Exception as err:
                     _LOGGER.debug('Could not fetch location data: %s' % err)
 
                 # fetch vehicle details data
                 try:
-                    vehicle_details = self.post('-/vehicle-info/get-vehicle-details', rel)
+                    vehicle_details = self.post(
+                        '-/vehicle-info/get-vehicle-details', rel)
                     if vehicle_details.get('errorCode', {}) == '0' and vehicle_details.get('vehicleDetails', {}):
-                        self._state[vin]['vehicle-details'] = vehicle_details.get('vehicleDetails', {})
+                        self._state[vin]['vehicle-details'] = vehicle_details.get(
+                            'vehicleDetails', {})
                 except Exception as err:
                     _LOGGER.debug('Could not fetch details data: %s' % err)
 
                 if vehicle['engineTypeCombustian']:
-                    # fetch remote auxiliary heating status data
+                    # fetch combustion engine remote auxiliary heating status data
                     try:
                         vehicle_status = self.post('-/rah/get-status')
                         if vehicle_status.get('errorCode', {}) == '0' and vehicle_status.get('remoteAuxiliaryHeating', {}):
-                            self._state[vin]['remoteAuxiliaryHeating'] = vehicle_status.get('remoteAuxiliaryHeating', {})
+                            self._state[vin]['remoteAuxiliaryHeating'] = vehicle_status.get(
+                                'remoteAuxiliaryHeating', {})
                     except Exception as err:
-                        _LOGGER.debug('Could not fetch remoteAuxiliaryHeating data: %s' % err)
+                        _LOGGER.debug(
+                            'Could not fetch remoteAuxiliaryHeating data: %s' % err)
 
                 _LOGGER.debug('State: %s', self._state)
 
             return True
         except (IOError, OSError) as error:
-            _LOGGER.warning('Could not update information from carnet: %s', error)
+            _LOGGER.warning(
+                'Could not update information from carnet: %s', error)
 
     def vehicle(self, vin):
         """Return vehicle for given vin."""
@@ -354,9 +393,11 @@ class Connection(object):
         except (IOError, OSError) as error:
             _LOGGER.warning('Could not validate login: %s', error)
             return False
+
     @property
     def logged_in(self):
         return self._session_logged_in
+
 
 class Vehicle(object):
     def __init__(self, conn, vin, data):
@@ -366,13 +407,15 @@ class Vehicle(object):
 
     def get(self, query):
         """Perform a query to the online service."""
-        rel = self._connection._session_base + self.data.get('dashboardUrl') + '/'
+        rel = self._connection._session_base + \
+            self.data.get('dashboardUrl') + '/'
         req = self._connection.get(query, rel)
         return req
 
     def post(self, query, **data):
         """Perform a query to the online service."""
-        rel = self._connection._session_base + self.data.get('dashboardUrl') + '/'
+        rel = self._connection._session_base + \
+            self.data.get('dashboardUrl') + '/'
         req = self._connection.post(query, rel, **data)
         return req
 
@@ -406,12 +449,12 @@ class Vehicle(object):
         from dashboard import Dashboard
         return Dashboard(self, **config)
 
-
     @property
     def last_connected(self):
         """Return when vehicle was last connected to carnet"""
         if self.last_connected_supported:
-            last_connected = self.data.get('vehicle-details', {}).get('lastConnectionTimeStamp', {})
+            last_connected = self.data.get(
+                'vehicle-details', {}).get('lastConnectionTimeStamp', {})
             if last_connected:
                 last_connected = last_connected[0] + last_connected[1]
                 date_patterns = ["%d.%m.%Y%H:%M", "%d-%m-%Y%H:%M"]
@@ -424,14 +467,16 @@ class Vehicle(object):
     @property
     def last_connected_supported(self):
         """Return when vehicle was last connected to carnet"""
-        check = self.data.get('vehicle-details', {}).get('lastConnectionTimeStamp', {})
+        check = self.data.get('vehicle-details', {}
+                              ).get('lastConnectionTimeStamp', {})
         if check:
             return True
 
     @property
     def climatisation_target_temperature(self):
         if self.climatisation_supported:
-            temperature = self.data.get('emanager', {}).get('rpc', {}).get('settings',{}).get('targetTemperature', {})
+            temperature = self.data.get('emanager', {}).get(
+                'rpc', {}).get('settings', {}).get('targetTemperature', {})
             if temperature:
                 return temperature
 
@@ -443,7 +488,7 @@ class Vehicle(object):
     @property
     def climatisation_without_external_power(self):
         if self.climatisation_without_external_power_supported:
-            return self.data.get('emanager', {}).get('rpc', {}).get('settings',{}).get('climatisationWithoutHVPower', {})
+            return self.data.get('emanager', {}).get('rpc', {}).get('settings', {}).get('climatisationWithoutHVPower', {})
 
     @property
     def climatisation_without_external_power_supported(self):
@@ -454,13 +499,15 @@ class Vehicle(object):
     def service_inspection(self):
         """Return time left for service inspection"""
         if self.service_inspection_supported:
-            check = self.data.get('vehicle-details', {}).get('serviceInspectionData', {})
+            check = self.data.get('vehicle-details', {}
+                                  ).get('serviceInspectionData', {})
             if check:
                 return check
 
     @property
     def service_inspection_supported(self):
-        check = self.data.get('vehicle-details', {}).get('serviceInspectionData', {})
+        check = self.data.get('vehicle-details', {}
+                              ).get('serviceInspectionData', {})
         if check:
             return True
 
@@ -468,13 +515,15 @@ class Vehicle(object):
     def oil_inspection(self):
         """Return time left for service inspection"""
         if self.service_inspection_supported:
-            check = self.data.get('vehicle-details', {}).get('oilInspectionData', {})
+            check = self.data.get('vehicle-details', {}
+                                  ).get('oilInspectionData', {})
             if check:
                 return check
 
     @property
     def oil_inspection_supported(self):
-        check = self.data.get('vehicle-details', {}).get('oilInspectionData', {})
+        check = self.data.get('vehicle-details', {}
+                              ).get('oilInspectionData', {})
         if check:
             return True
 
@@ -486,7 +535,8 @@ class Vehicle(object):
 
     @property
     def battery_level_supported(self):
-        check = self.data.get('emanager', {}).get('rbc', {}).get('status', {}).get('batteryPercentage', {})
+        check = self.data.get('emanager', {}).get('rbc', {}).get(
+            'status', {}).get('batteryPercentage', {})
         if isinstance(check, int):
             return True
 
@@ -498,7 +548,8 @@ class Vehicle(object):
 
     @property
     def charge_max_ampere_supported(self):
-        check = self.data.get('emanager', {}).get('rbc', {}).get('settings', {}).get('chargerMaxCurrent', {})
+        check = self.data.get('emanager', {}).get('rbc', {}).get(
+            'settings', {}).get('chargerMaxCurrent', {})
         if isinstance(check, int):
             return True
 
@@ -506,7 +557,8 @@ class Vehicle(object):
     def parking_light(self):
         """Return true if parking light is on"""
         if self.parking_light_supported:
-            check = self.data.get('vsr', {}).get('carRenderData', {}).get('parkingLights', {})
+            check = self.data.get('vsr', {}).get(
+                'carRenderData', {}).get('parkingLights', {})
             if check != 2:
                 return True
             else:
@@ -515,22 +567,25 @@ class Vehicle(object):
     @property
     def parking_light_supported(self):
         """Return true if parking light is supported"""
-        check = self.data.get('vsr', {}).get('carRenderData',{}).get('parkingLights', {})
+        check = self.data.get('vsr', {}).get(
+            'carRenderData', {}).get('parkingLights', {})
         if isinstance(check, int):
             return True
 
     @property
     def distance(self):
         if self.distance_supported:
-            value = self.data.get('vehicle-details',{}).get('distanceCovered', None).replace('.', '').replace(',','').replace('--', '')
+            value = self.data.get('vehicle-details', {}).get('distanceCovered',
+                                                             None).replace('.', '').replace(',', '').replace('--', '')
             if value:
                 return int(value)
 
     @property
     def distance_supported(self):
         """Return true if distance is supported"""
-        check = self.data.get('vehicle-details',{}).get('distanceCovered', {})
-        if check: return True
+        check = self.data.get('vehicle-details', {}).get('distanceCovered', {})
+        if check:
+            return True
 
     @property
     def position(self):
@@ -542,7 +597,8 @@ class Vehicle(object):
     def position_supported(self):
         """Return true if vehichle has position."""
         check = self.data.get('position', {}).get('lng', {})
-        if check: return True
+        if check:
+            return True
 
     @property
     def model(self):
@@ -553,7 +609,8 @@ class Vehicle(object):
     @property
     def model_supported(self):
         check = self.data.get('model')
-        if check: return True
+        if check:
+            return True
 
     @property
     def model_year(self):
@@ -564,7 +621,8 @@ class Vehicle(object):
     @property
     def model_year_supported(self):
         check = self.data.get('modelYear', {})
-        if check: return True
+        if check:
+            return True
 
     @property
     def model_image(self):
@@ -575,13 +633,15 @@ class Vehicle(object):
     @property
     def model_image_supported(self):
         check = self.data.get('imageUrl', {})
-        if check: return True
+        if check:
+            return True
 
     @property
     def charging(self):
         """Return status of charging."""
         if self.charging_supported:
-            status = self.data.get('emanager', {}).get('rbc', {}).get('status', {}).get('chargingState', {})
+            status = self.data.get('emanager', {}).get(
+                'rbc', {}).get('status', {}).get('chargingState', {})
             if status == 'CHARGING':
                 return True
             else:
@@ -590,7 +650,8 @@ class Vehicle(object):
     @property
     def charging_supported(self):
         """Return true if vehichle has heater."""
-        check = self.data.get('emanager', {}).get('rbc', {}).get('status',{}).get('batteryPercentage', {})
+        check = self.data.get('emanager', {}).get('rbc', {}).get(
+            'status', {}).get('batteryPercentage', {})
         if check:
             return True
 
@@ -601,7 +662,8 @@ class Vehicle(object):
 
     @property
     def electric_range_supported(self):
-        check = self.data.get('emanager', {}).get('rbc', {}).get('status', {}).get('electricRange', {})
+        check = self.data.get('emanager', {}).get(
+            'rbc', {}).get('status', {}).get('electricRange', {})
         if isinstance(check, int):
             return True
 
@@ -612,10 +674,10 @@ class Vehicle(object):
 
     @property
     def combustion_range_supported(self):
-        check = self.data.get('emanager', {}).get('rbc', {}).get('status', {}).get('combustionRange', {})
+        check = self.data.get('emanager', {}).get('rbc', {}).get(
+            'status', {}).get('combustionRange', {})
         if isinstance(check, int):
             return True
-
 
     @property
     def combined_range(self):
@@ -624,7 +686,8 @@ class Vehicle(object):
 
     @property
     def combined_range_supported(self):
-        check = self.data.get('emanager', {}).get('rbc', {}).get('status', {}).get('combinedRange', {})
+        check = self.data.get('emanager', {}).get(
+            'rbc', {}).get('status', {}).get('combinedRange', {})
         if isinstance(check, int):
             return True
 
@@ -643,7 +706,8 @@ class Vehicle(object):
     def external_power(self):
         """Return true if external power is connected."""
         if self.external_power_supported:
-            check = self.data.get('emanager', {}).get('rbc', {}).get('status', {}).get('pluginState', {})
+            check = self.data.get('emanager', {}).get(
+                'rbc', {}).get('status', {}).get('pluginState', {})
             if check == 'CONNECTED':
                 return True
             else:
@@ -653,22 +717,27 @@ class Vehicle(object):
     def external_power_supported(self):
         """External power supported."""
         if self.charging_supported:
-            check = self.data.get('emanager', {}).get('rbc', {}).get('status', {}).get('pluginState', {})
-            if check: return True
+            check = self.data.get('emanager', {}).get(
+                'rbc', {}).get('status', {}).get('pluginState', {})
+            if check:
+                return True
 
     @property
     def climatisation(self):
         """Return status of climatisation."""
         if self.climatisation_supported:
-            status = self.data.get('emanager', {}).get('rpc', {}).get('status',{}).get('climatisationState', {})
+            status = self.data.get('emanager', {}).get('rpc', {}).get(
+                'status', {}).get('climatisationState', {})
             if status == 'HEATING':
                 return True
             else:
                 return False
+
     @property
     def climatisation_supported(self):
         """Return true if vehichle has heater."""
-        check = self.data.get('emanager', {}).get('rpc', {}).get('climaterActionState', {})
+        check = self.data.get('emanager', {}).get(
+            'rpc', {}).get('climaterActionState', {})
         if check == 'AVAILABLE' or check == 'NO_PLUGIN':
             return True
 
@@ -677,11 +746,13 @@ class Vehicle(object):
         """Return status of window heater."""
         if self.window_heater_supported:
             ret = False
-            status_front = self.data.get('emanager', {}).get('rpc', {}).get('status', {}).get('windowHeatingStateFront', {})
+            status_front = self.data.get('emanager', {}).get('rpc', {}).get(
+                'status', {}).get('windowHeatingStateFront', {})
             if status_front == 'ON':
                 ret = True
 
-            status_rear = self.data.get('emanager', {}).get('rpc', {}).get('status', {}).get('windowHeatingStateRear', {})
+            status_rear = self.data.get('emanager', {}).get('rpc', {}).get(
+                'status', {}).get('windowHeatingStateRear', {})
             if status_rear == 'ON':
                 ret = True
             return ret
@@ -690,21 +761,25 @@ class Vehicle(object):
     def window_heater_supported(self):
         """Return true if vehichle has heater."""
         if self.climatisation_supported:
-            check = self.data.get('emanager', {}).get('rpc', {}).get('status',{}).get('windowHeatingAvailable', {})
-            if check: return True
+            check = self.data.get('emanager', {}).get('rpc', {}).get(
+                'status', {}).get('windowHeatingAvailable', {})
+            if check:
+                return True
 
     @property
-    def remote_access_heating(self):
-        """Return status of remote access heating."""
-        if self.remote_access_heating_supported:
-            status_remote_access_heating_active = self.data.get('remoteAuxiliaryHeating').get('status').get('active', False)
-            return status_remote_access_heating_active
+    def combustion_engine_heating(self):
+        """Return status of combustion engine heating."""
+        if self.combustion_engine_heating_supported:
+            status_combustion_engine_heating_active = self.data.get(
+                'remoteAuxiliaryHeating').get('status').get('active', False)
+            return status_combustion_engine_heating_active
 
     @property
-    def remote_access_heating_supported(self):
-        """Return true if vehichle has remote access heating."""
+    def combustion_engine_heating_supported(self):
+        """Return true if vehichle has combustion engine heating."""
         check = self.data.get('remoteAuxiliaryHeating', {})
-        if check: return True
+        if check:
+            return True
 
     @property
     def window_supported(self):
@@ -717,8 +792,10 @@ class Vehicle(object):
     def charging_time_left(self):
         if self.charging_supported:
             if self.external_power:
-                hours = self.data.get('emanager', {}).get('rbc', {}).get('status', {}).get('chargingRemaningHour', {})
-                minutes = self.data.get('emanager', {}).get('rbc', {}).get('status', {}).get('chargingRemaningMinute', {})
+                hours = self.data.get('emanager', {}).get('rbc', {}).get(
+                    'status', {}).get('chargingRemaningHour', {})
+                minutes = self.data.get('emanager', {}).get('rbc', {}).get(
+                    'status', {}).get('chargingRemaningMinute', {})
                 if hours and minutes:
                     # return 0 if we are not able to convert the values we get from carnet.
                     try:
@@ -752,11 +829,13 @@ class Vehicle(object):
     @property
     def trunk_locked(self):
         if self.trunk_locked_supported:
-            trunk_lock_data = self.data.get('vsr', {}).get('lockData', {}).get('trunk')
+            trunk_lock_data = self.data.get(
+                'vsr', {}).get('lockData', {}).get('trunk')
             if trunk_lock_data != 2:
                 return False
             else:
                 return True
+
     @property
     def trunk_locked_supported(self):
         check = self.data.get('vsr', {}).get('lockData', {}).get('trunk')
@@ -776,7 +855,6 @@ class Vehicle(object):
         check = self.data.get('vsr', {}).get('requestStatus', {})
         if check:
             return True
-
 
     # states
     @property
@@ -803,7 +881,8 @@ class Vehicle(object):
     def is_climatisation_on(self):
         """Return status of climatisation."""
         if self.climatisation_supported:
-            status = self.data.get('emanager', {}).get('rpc', {}).get('status',{}).get('climatisationState', {})
+            status = self.data.get('emanager', {}).get('rpc', {}).get(
+                'status', {}).get('climatisationState', {})
             if status == 'HEATING':
                 return True
             else:
@@ -814,11 +893,13 @@ class Vehicle(object):
         """Return status of window heater."""
         if self.window_heater_supported:
             ret = False
-            status_front = self.data.get('emanager', {}).get('rpc', {}).get('status', {}).get('windowHeatingStateFront', {})
+            status_front = self.data.get('emanager', {}).get('rpc', {}).get(
+                'status', {}).get('windowHeatingStateFront', {})
             if status_front == 'ON':
                 ret = True
 
-            status_rear = self.data.get('emanager', {}).get('rpc', {}).get('status', {}).get('windowHeatingStateRear', {})
+            status_rear = self.data.get('emanager', {}).get('rpc', {}).get(
+                'status', {}).get('windowHeatingStateRear', {})
             if status_rear == 'ON':
                 ret = True
             return ret
@@ -827,7 +908,8 @@ class Vehicle(object):
     def is_charging_on(self):
         """Return status of charging."""
         if self.charging_supported:
-            status = self.data.get('emanager', {}).get('rbc', {}).get('status', {}).get('chargingState', {})
+            status = self.data.get('emanager', {}).get(
+                'rbc', {}).get('status', {}).get('chargingState', {})
             if status == 'CHARGING':
                 return True
             else:
@@ -845,19 +927,20 @@ class Vehicle(object):
     def start_climatisation(self):
         """Turn on/off climatisation."""
         if self.climatisation_supported:
-            resp = self.call('-/emanager/trigger-climatisation', triggerAction=True, electricClima=True)
+            resp = self.call('-/emanager/trigger-climatisation',
+                             triggerAction=True, electricClima=True)
             if not resp:
                 _LOGGER.warning('Failed to start climatisation')
             else:
                 return resp
         else:
             _LOGGER.error('No climatization support.')
-            
 
     def stop_climatisation(self):
         """Turn on/off climatisation."""
         if self.climatisation_supported:
-            resp = self.call('-/emanager/trigger-climatisation', triggerAction=False, electricClima=True)
+            resp = self.call('-/emanager/trigger-climatisation',
+                             triggerAction=False, electricClima=True)
             if not resp:
                 _LOGGER.warning('Failed to stop climatisation')
             else:
@@ -868,7 +951,8 @@ class Vehicle(object):
     def start_window_heater(self):
         """Turn on/off window heater."""
         if self.window_heater_supported:
-            resp = self.call('-/emanager/trigger-windowheating', triggerAction=True)
+            resp = self.call(
+                '-/emanager/trigger-windowheating', triggerAction=True)
             if not resp:
                 _LOGGER.warning('Failed to start window heater')
             else:
@@ -879,39 +963,42 @@ class Vehicle(object):
     def stop_window_heater(self):
         """Turn on/off window heater."""
         if self.window_heater_supported:
-            resp = self.call('-/emanager/trigger-windowheating', triggerAction=False)
+            resp = self.call(
+                '-/emanager/trigger-windowheating', triggerAction=False)
             if not resp:
                 _LOGGER.warning('Failed to stop window heater')
         else:
             _LOGGER.error('No window heating support.')
 
-    def start_remote_access_heating(self, spin):
+    def start_combustion_engine_heating(self, spin):
         if spin:
-            if self.remote_access_heating_supported:
-                resp = self.call('-/rah/quick-start', startMode='HEATING', spin=spin)
+            if self.combustion_engine_heating_supported:
+                resp = self.call('-/rah/quick-start',
+                                 startMode='HEATING', spin=spin)
                 if not resp:
-                    _LOGGER.warning('Failed to start remote access heating')
+                    _LOGGER.warning('Failed to start combustion engine heating')
                 else:
                     return resp
             else:
-                _LOGGER.error('No remote access heating support.')
-        else: 
+                _LOGGER.error('No combustion engine heating support.')
+        else:
             _LOGGER.error('Invalid SPIN provided')
 
-    def stop_remote_access_heating(self):
-        if self.remote_access_heating_supported:
+    def stop_combustion_engine_heating(self):
+        if self.combustion_engine_heating_supported:
             resp = self.call('-/rah/quick-stop')
             if not resp:
-                _LOGGER.warning('Failed to stop remote access_ eating')
+                _LOGGER.warning('Failed to stop combustion engine heating')
             else:
                 return resp
         else:
-            _LOGGER.error('No remote access heating support.')
+            _LOGGER.error('No combustion engine heating support.')
 
     def start_charging(self):
         """Turn on/off window heater."""
         if self.charging_supported:
-            resp = self.call('-/emanager/charge-battery', triggerAction=True, batteryPercent='100')
+            resp = self.call('-/emanager/charge-battery',
+                             triggerAction=True, batteryPercent='100')
             if not resp:
                 _LOGGER.warning('Failed to start charging')
             else:
@@ -922,7 +1009,8 @@ class Vehicle(object):
     def stop_charging(self):
         """Turn on/off window heater."""
         if self.charging_supported:
-            resp = self.call('-/emanager/charge-battery', triggerAction=False, batteryPercent='99')
+            resp = self.call('-/emanager/charge-battery',
+                             triggerAction=False, batteryPercent='99')
             if not resp:
                 _LOGGER.warning('Failed to stop charging')
             else:
@@ -933,15 +1021,17 @@ class Vehicle(object):
     def set_climatisation_target_temperature(self, target_temperature):
         """Turn on/off window heater."""
         if self.climatisation_supported:
-            resp = self.call('-/emanager/set-settings', chargerMaxCurrent=None, climatisationWithoutHVPower=None, minChargeLimit=None, targetTemperature = target_temperature)
+            resp = self.call('-/emanager/set-settings', chargerMaxCurrent=None,
+                             climatisationWithoutHVPower=None, minChargeLimit=None, targetTemperature=target_temperature)
             if not resp:
-                _LOGGER.warning('Failed to set target temperature for climatisation')
+                _LOGGER.warning(
+                    'Failed to set target temperature for climatisation')
             else:
                 return resp
         else:
             _LOGGER.error('No climatisation support.')
 
-    def get_status(self, timeout = 10):
+    def get_status(self, timeout=10):
         """Check status from call"""
         retry_counter = 0
         while retry_counter < timeout:
@@ -952,7 +1042,6 @@ class Vehicle(object):
             time.sleep(1)
             retry_counter += 1
         return False
-
 
     def __str__(self):
         return self.vin

--- a/volkswagencarnet.py
+++ b/volkswagencarnet.py
@@ -18,7 +18,7 @@ from utilities import find_path, is_valid_path
 
 version_info >= (3, 0) or exit('Python 3 required')
 
-__version__ = '4.1.2'
+__version__ = '4.1.3'
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -322,7 +322,7 @@ class Connection(object):
                         vehicle_status = self.post('-/rah/get-status')
                         if vehicle_status.get('errorCode', {}) == '0' and vehicle_status.get('remoteAuxiliaryHeating', {}):
                             self._state[vin]['remoteAuxiliaryHeating'] = vehicle_status.get('remoteAuxiliaryHeating', {})
-                except Exception as err:
+                    except Exception as err:
                         _LOGGER.debug('Could not fetch remoteAuxiliaryHeating data: %s' % err)
 
                 _LOGGER.debug('State: %s', self._state)


### PR DESCRIPTION
My goal was to be able to turn om my car heater for my VW Golf from Home assistant, since the WE-connect app is so slow 😠 .

First time writing Python, but easy to follow the code current code semantics. 

To be able to use the features for cars with `engineTypeCombustian` there is need to provide a S-PIN to those actions. Currently there is only one action (`start_combustion_engine_heating`) that is using it, but will be needed if/when adding other features.

I had some troubles with the `configuration.py` file. It seem to be needed but missing in the repo.
Can't figure out why it did work for some time then suddenly stopped. Saying that the configuration module is missing.

Solved it by creating a new one. But maybe @robinostlund can shed some light for me on why it works for him without adding the file in the repo.

Will update the readme when the PR get reviewed and approved. 
