### PR TITLE
Add method to request car to report its state

### DIFF
--- a/volkswagencarnet.py
+++ b/volkswagencarnet.py
@@ -1300,6 +1300,14 @@ class Vehicle:
         else:
             _LOGGER.error('No climatisation support.')
 
+    async def request_report(self):
+        """Request car to report its state when connected."""
+        resp = await self.call('-/vhr/create-report')
+        if not resp:
+            _LOGGER.warning('Failed to request new report generation')
+        else:
+            return resp
+
     async def get_status(self, timeout=10):
         """Check status from call"""
         retry_counter = 0


### PR DESCRIPTION
This method triggers a request to send an update by a selected car.

Some car doesn't update on its own and needs to be "requested for report" so they can update their data after they got connected to WLAN.

This method adds possiblity to trigger this report generation from API.

Closes #105