### PR TITLE
Exposes hvac mode on climate model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+__pycache__

--- a/volkswagencarnet.py
+++ b/volkswagencarnet.py
@@ -8,6 +8,7 @@ import asyncio
 
 from sys import version_info, argv
 from datetime import timedelta, datetime
+from typing import Union
 from urllib.parse import urlsplit, urljoin, parse_qs, urlparse
 from json import dumps as to_json
 from collections import OrderedDict
@@ -777,12 +778,12 @@ class Vehicle:
             return True
 
     @property
-    def electric_climatisation(self):
+    def electric_climatisation(self) -> Union[str, bool]:
         """Return status of climatisation."""
         climatisation_type = self.attrs.get('vehicleEmanager', {}).get('rpc', {}).get('settings', {}).get('electric', False)
         status = self.attrs.get('vehicleEmanager', {}).get('rpc', {}).get('status', {}).get('climatisationState', '')
         if status in ['HEATING', 'COOLING'] and climatisation_type is True:
-            return True
+            return status
         else:
             return False
 
@@ -799,12 +800,12 @@ class Vehicle:
         return self.is_climatisation_supported
 
     @property
-    def combustion_climatisation(self):
+    def combustion_climatisation(self) -> Union[str, bool]:
         """Return status of combustion climatisation."""
         climatisation_type = self.attrs.get('vehicleEmanager', {}).get('rpc', {}).get('settings', {}).get('electric', False)
         status = self.attrs.get('vehicleEmanager', {}).get('rpc', {}).get('status', {}).get('climatisationState', '')
         if status and status in ['HEATING', 'COOLING'] and climatisation_type is False:
-            return True
+            return status
         else:
             return False
 

--- a/vw_dashboard.py
+++ b/vw_dashboard.py
@@ -2,6 +2,8 @@
 # Thanks to molobrakos
 
 import logging
+from typing import Union
+
 from vw_utilities import camel2slug
 
 _LOGGER = logging.getLogger(__name__)
@@ -207,7 +209,7 @@ class ElectricClimatisationClimate(Climate):
         super().__init__(attr="electric_climatisation", name="Electric Climatisation", icon="mdi:radiator")
 
     @property
-    def hvac_mode(self):
+    def hvac_mode(self) -> Union[str, bool]:
         return self.vehicle.electric_climatisation
 
     @property
@@ -232,7 +234,7 @@ class CombustionClimatisationClimate(Climate):
         self.spin = config.get('spin', '')
 
     @property
-    def hvac_mode(self):
+    def hvac_mode(self) -> Union[str, bool]:
         return self.vehicle.combustion_climatisation
 
     @property
@@ -365,7 +367,7 @@ class ElectricClimatisation(Switch):
 
     @property
     def state(self):
-        return self.vehicle.electric_climatisation
+        return self.vehicle.electric_climatisation is not False
 
     async def turn_on(self):
         await self.vehicle.start_electric_climatisation()
@@ -447,7 +449,7 @@ class CombustionClimatisation(Switch):
 
     @property
     def state(self):
-        return self.vehicle.combustion_climatisation
+        return self.vehicle.combustion_climatisation is not False
 
     async def turn_on(self):
         await self.vehicle.start_combustion_climatisation(self.spin)


### PR DESCRIPTION
Not sure if this is correct since Im not able to test it myself. It also requires a change in the HA integration.

Something like this

```python
    @property
    def hvac_mode(self):
        """Return hvac operation ie. heat, cool mode.
        Need to be one of HVAC_MODE_*.
        """
        if not self.instrument.hvac_mode:
            return HVAC_MODE_OFF

        hvac_modes = {
            'heating': HVAC_MODE_HEAT,
            'cooling': HVAC_MODE_COOL,
        }
        return hvac_modes.get(self.instrument.hvac_mode, HVAC_MODE_OFF)
```

Will make a PR for that if this one makes sense.