### PR TITLE
Unpin pyjwt and support version 2+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ lxml
 beautifulsoup4
 aiohttp
 pytest-asyncio
-pyjwt==1.7.1
+pyjwt


### PR DESCRIPTION
This implementation should be backwards compatible with pyjwt 1.7.1. Closes #126.