### PR TITLE
Change README example: use doLogin instead of _login

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ async def main():
     """Main method."""
     async with ClientSession(headers={'Connection': 'keep-alive'}) as session:
         connection = volkswagencarnet.Connection(session, VW_USERNAME, VW_PASSWORD)
-        if await connection._login():
+        if await connection.doLogin():
             if await connection.update():
                 # Print overall state
                 pprint.pprint(connection._state)


### PR DESCRIPTION
See #130

Using volkswagencarnet.Connection._login results in an erroneous login state. I propose that the example code in the README.md is changed so that others don't run into the same problem.