### PR TITLE
disable verification of audience to avoid "Invalid audience" errors on decoding jwt tokens

### DIFF
--- a/vw_connection.py
+++ b/vw_connection.py
@@ -1094,8 +1094,8 @@ class Connection:
         """Function to validate expiry of tokens."""
         idtoken = self._session_tokens['identity']['id_token']
         atoken = self._session_tokens['vwg']['access_token']
-        id_exp = jwt.decode(idtoken, options={"verify_signature": False}, algorithms=JWT_ALGORITHMS).get('exp', None)
-        at_exp = jwt.decode(atoken, options={"verify_signature": False}, algorithms=JWT_ALGORITHMS).get('exp', None)
+        id_exp = jwt.decode(idtoken, options={"verify_signature": False, 'verify_aud': False}, algorithms=JWT_ALGORITHMS).get('exp', None)
+        at_exp = jwt.decode(atoken, options={"verify_signature": False, 'verify_aud': False}, algorithms=JWT_ALGORITHMS).get('exp', None)
         id_dt = datetime.fromtimestamp(int(id_exp))
         at_dt = datetime.fromtimestamp(int(at_exp))
         now = datetime.now()


### PR DESCRIPTION
I also got the "Invalid audience" Error after upgrading to v4.4.36 today.
See issue: [https://github.com/robinostlund/volkswagencarnet/issues/131]

I have no clue why this is happening, but can you disable this verification when checking the expiration of tokens?