### PR TITLE
Fix multiple homeregions

### DIFF
--- a/vw_connection.py
+++ b/vw_connection.py
@@ -536,9 +536,10 @@ class Connection:
             # Get all Vehicle objects and update in parallell
             updatelist = []
             for vehicle in self.vehicles:
-                updatelist.append(vehicle.update())
+                #updatelist.append(vehicle.update())
+                await vehicle.update()
             # Wait for all data updates to complete
-            await asyncio.gather(*updatelist)
+            #await asyncio.gather(*updatelist)
 
             return True
         except (IOError, OSError, LookupError, Exception) as error:


### PR DESCRIPTION
This is a fix for https://github.com/robinostlund/volkswagencarnet/issues/136 that have been working well for me for a month. Basic problem is that the potential different homeregions when having more than one vehicle for an account creates "static" urls during login phase in _make_url to be used throughout the session. This leads to that only vehicles with the matching homeregion will get sensor updates, actions etc.