### PR TITLE
Add renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,15 @@
+{
+  "extends": [
+    "config:base",
+    ":preserveSemverRanges"
+  ],
+  "labels": ["dependencies"],
+  "draftPR": true,
+  "internalChecksFilter": "strict",
+  "pip_requirements": {
+    "fileMatch": ["requirements-test.(txt|pip)"]
+  },
+  "pre-commit": {
+    "enabled": true
+  }
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
 package_dir =
   = .
 packages = find:
-python_requires = >= 3.6
+python_requires = >= 3.7
 
 [options.packages.find]
 where = .


### PR DESCRIPTION
@robinostlund do you have strong opinions about dependabot vs renovate? I tested out renovate (which has support for updating the pre-commit versions also), and this is what the onboarding PR says.

Oh, and regarding dependency versions. Runtime dependencies probably should have some ranges defined (I'm fairly sure things would break with ancient versions of some of them), and test/build ones could probably be pinned to exact versions?

![image](https://user-images.githubusercontent.com/1941814/154434528-0970c90c-1724-4de7-ad74-30a706fcc23d.png)
