### PR TITLE
Add timer programming feature

### DIFF
--- a/tests/fixtures/connection.py
+++ b/tests/fixtures/connection.py
@@ -1,17 +1,13 @@
 """Session and connection related test fixtures."""
 import os
-from pathlib import Path
 
 import pytest
 import pytest_asyncio
 from aiohttp import CookieJar, ClientSession
 
+from .constants import timers_json_file, resource_path
 from volkswagencarnet.vw_connection import Connection
-
-current_path = Path(os.path.dirname(os.path.realpath(__file__)))
-resource_path = os.path.join(current_path, "resources")
-
-status_report_json_file = os.path.join(resource_path, "responses", "status.json")
+from volkswagencarnet.vw_utilities import json_loads
 
 
 @pytest_asyncio.fixture
@@ -28,3 +24,26 @@ async def session():
 def connection(session):
     """Real connection for integration tests."""
     return Connection(session=session, username="", password="", country="DE", interval=999, fulldebug=True)
+
+
+class TimersConnection:
+    """Connection that has timers defined."""
+
+    def __init__(self, sess, **kwargs):
+        """Init."""
+        self._session = sess
+
+    async def doLogin(self):
+        """No-op login."""
+        return True
+
+    async def update(self):
+        """No-op update."""
+        return True
+
+    async def getTimers(self, vin):
+        """Get timers data from backend."""
+        # test with a "real" response
+        with open(timers_json_file) as f:
+            data = json_loads(f.read())
+            return data

--- a/tests/fixtures/connection.py
+++ b/tests/fixtures/connection.py
@@ -4,6 +4,7 @@ import os
 import pytest
 import pytest_asyncio
 from aiohttp import CookieJar, ClientSession
+from volkswagencarnet.vw_timer import TimerData
 
 from .constants import timers_json_file, resource_path
 from volkswagencarnet.vw_connection import Connection
@@ -45,5 +46,6 @@ class TimersConnection:
         """Get timers data from backend."""
         # test with a "real" response
         with open(timers_json_file) as f:
-            data = json_loads(f.read())
-            return data
+            json = json_loads(f.read()).get("timer", {})
+            data = TimerData(**json)
+            return {"timer": data}

--- a/tests/fixtures/connection.py
+++ b/tests/fixtures/connection.py
@@ -48,4 +48,4 @@ class TimersConnection:
         with open(timers_json_file) as f:
             json = json_loads(f.read()).get("timer", {})
             data = TimerData(**json)
-            return {"timer": data}
+            return data

--- a/tests/fixtures/constants.py
+++ b/tests/fixtures/constants.py
@@ -1,0 +1,10 @@
+"""Misc constants and other data for tests."""
+import os
+from pathlib import Path
+
+MOCK_VIN = "WVWZZZAUZFW000000"
+
+current_path = Path(os.path.dirname(os.path.realpath(__file__)))
+resource_path = os.path.join(current_path, "resources")
+status_report_json_file = os.path.join(resource_path, "responses", "status.json")
+timers_json_file = os.path.join(resource_path, "responses", "timer.json")

--- a/tests/fixtures/resources/responses/timer.json
+++ b/tests/fixtures/resources/responses/timer.json
@@ -2,11 +2,11 @@
   "timer": {
     "timersAndProfiles": {
       "timerProfileList": {
-        "profiles": [
+        "timerProfile": [
           {
             "timestamp": "2022-02-22T20:00:22Z",
             "profileName": "Profile 1",
-            "profileId": "1",
+            "profileID": "1",
             "operationCharging": true,
             "operationClimatisation": false,
             "targetChargeLevel": "75",
@@ -18,20 +18,22 @@
         ]
       },
       "timerList": {
-        "timers": [
+        "timer": [
           {
             "timestamp": "2022-02-22T20:00:22Z",
             "timerID": "3",
+            "profileID": "1",
             "timerProgrammedStatus": "notProgrammed",
+            "timerFrequency": "cyclic",
             "departureTimeOfDay": "07:55",
             "departureWeekdayMask": "nnnnnyn"
           }
         ]
       },
       "timerBasicSetting": {
-        "ts": "2022-02-22T20:00:22Z",
-        "charge_min_limit": "20",
-        "target_temperature": "2955"
+        "timestamp": "2022-02-22T20:00:22Z",
+        "chargeMinLimit": "20",
+        "targetTemperature": "2955"
       }
     },
     "status": {

--- a/tests/fixtures/resources/responses/timer.json
+++ b/tests/fixtures/resources/responses/timer.json
@@ -1,0 +1,119 @@
+{
+  "timer": {
+    "timersAndProfiles": {
+      "timerProfileList": {
+        "timerProfile": [
+          {
+            "timestamp": "2022-02-22T20:00:22Z",
+            "profileName": "Profile 1",
+            "profileID": "1",
+            "operationCharging": true,
+            "operationClimatisation": false,
+            "targetChargeLevel": "75",
+            "nightRateActive": true,
+            "nightRateTimeStart": "21:00",
+            "nightRateTimeEnd": "05:00",
+            "chargeMaxCurrent": "10"
+          },
+          {
+            "timestamp": "2022-02-22T20:00:22Z",
+            "profileName": "Profile 2",
+            "profileID": "2",
+            "operationCharging": true,
+            "operationClimatisation": true,
+            "targetChargeLevel": "100",
+            "nightRateActive": true,
+            "nightRateTimeStart": "20:00",
+            "nightRateTimeEnd": "05:00",
+            "chargeMaxCurrent": "10"
+          },
+          {
+            "timestamp": "2022-02-22T20:00:22Z",
+            "profileName": "Profile 3",
+            "profileID": "3",
+            "operationCharging": true,
+            "operationClimatisation": false,
+            "targetChargeLevel": "60",
+            "nightRateActive": false,
+            "nightRateTimeStart": "00:00",
+            "nightRateTimeEnd": "00:00",
+            "chargeMaxCurrent": "10"
+          }
+        ]
+      },
+      "timerList": {
+        "timer": [
+          {
+            "timestamp": "2022-02-22T20:00:22Z",
+            "timerID": "3",
+            "profileID": "3",
+            "timerProgrammedStatus": "notProgrammed",
+            "timerFrequency": "cyclic",
+            "departureTimeOfDay": "07:55",
+            "departureWeekdayMask": "nnnnnyn"
+          },
+          {
+            "timestamp": "2022-02-22T20:00:22Z",
+            "timerID": "1",
+            "profileID": "5",
+            "timerProgrammedStatus": "programmed",
+            "timerFrequency": "cyclic",
+            "departureTimeOfDay": "05:00",
+            "departureWeekdayMask": "yyyyyyy"
+          },
+          {
+            "timestamp": "2022-02-22T20:00:22Z",
+            "timerID": "2",
+            "profileID": "5",
+            "timerProgrammedStatus": "programmed",
+            "timerFrequency": "single",
+            "departureTimeOfDay": "08:00",
+            "departureWeekdayMask": "nnnnnyy"
+          }
+        ]
+      },
+      "timerBasicSetting": {
+        "timestamp": "2022-02-22T20:00:22Z",
+        "chargeMinLimit": "20",
+        "targetTemperature": "2955"
+      }
+    },
+    "status": {
+      "timer": [
+        {
+          "timerID": "1",
+          "timerExpiredStatus": {
+            "timestamp": "2022-02-22T20:00:22Z",
+            "content": "notExpired"
+          },
+          "instrumentClusterTime": {
+            "timestamp": "2022-02-22T20:00:22Z",
+            "content": "2022-02-22T20:00:22Z"
+          }
+        },
+        {
+          "timerID": "2",
+          "timerExpiredStatus": {
+            "timestamp": "2022-02-22T20:00:22Z",
+            "content": "notExpired"
+          },
+          "instrumentClusterTime": {
+            "timestamp": "2022-02-22T20:00:22Z",
+            "content": "2022-02-22T20:00:22Z"
+          }
+        },
+        {
+          "timerID": "3",
+          "timerExpiredStatus": {
+            "timestamp": "2022-02-22T20:00:22Z",
+            "content": "notExpired"
+          },
+          "instrumentClusterTime": {
+            "timestamp": "2022-02-22T20:00:22Z",
+            "content": "2022-02-22T20:00:22Z"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/resources/responses/timer.json
+++ b/tests/fixtures/resources/responses/timer.json
@@ -2,11 +2,11 @@
   "timer": {
     "timersAndProfiles": {
       "timerProfileList": {
-        "timerProfile": [
+        "profiles": [
           {
             "timestamp": "2022-02-22T20:00:22Z",
             "profileName": "Profile 1",
-            "profileID": "1",
+            "profileId": "1",
             "operationCharging": true,
             "operationClimatisation": false,
             "targetChargeLevel": "75",
@@ -14,106 +14,28 @@
             "nightRateTimeStart": "21:00",
             "nightRateTimeEnd": "05:00",
             "chargeMaxCurrent": "10"
-          },
-          {
-            "timestamp": "2022-02-22T20:00:22Z",
-            "profileName": "Profile 2",
-            "profileID": "2",
-            "operationCharging": true,
-            "operationClimatisation": true,
-            "targetChargeLevel": "100",
-            "nightRateActive": true,
-            "nightRateTimeStart": "20:00",
-            "nightRateTimeEnd": "05:00",
-            "chargeMaxCurrent": "10"
-          },
-          {
-            "timestamp": "2022-02-22T20:00:22Z",
-            "profileName": "Profile 3",
-            "profileID": "3",
-            "operationCharging": true,
-            "operationClimatisation": false,
-            "targetChargeLevel": "60",
-            "nightRateActive": false,
-            "nightRateTimeStart": "00:00",
-            "nightRateTimeEnd": "00:00",
-            "chargeMaxCurrent": "10"
           }
         ]
       },
       "timerList": {
-        "timer": [
+        "timers": [
           {
             "timestamp": "2022-02-22T20:00:22Z",
             "timerID": "3",
-            "profileID": "3",
             "timerProgrammedStatus": "notProgrammed",
-            "timerFrequency": "cyclic",
             "departureTimeOfDay": "07:55",
             "departureWeekdayMask": "nnnnnyn"
-          },
-          {
-            "timestamp": "2022-02-22T20:00:22Z",
-            "timerID": "1",
-            "profileID": "5",
-            "timerProgrammedStatus": "programmed",
-            "timerFrequency": "cyclic",
-            "departureTimeOfDay": "05:00",
-            "departureWeekdayMask": "yyyyyyy"
-          },
-          {
-            "timestamp": "2022-02-22T20:00:22Z",
-            "timerID": "2",
-            "profileID": "5",
-            "timerProgrammedStatus": "programmed",
-            "timerFrequency": "single",
-            "departureTimeOfDay": "08:00",
-            "departureWeekdayMask": "nnnnnyy"
           }
         ]
       },
       "timerBasicSetting": {
-        "timestamp": "2022-02-22T20:00:22Z",
-        "chargeMinLimit": "20",
-        "targetTemperature": "2955"
+        "ts": "2022-02-22T20:00:22Z",
+        "charge_min_limit": "20",
+        "target_temperature": "2955"
       }
     },
     "status": {
-      "timer": [
-        {
-          "timerID": "1",
-          "timerExpiredStatus": {
-            "timestamp": "2022-02-22T20:00:22Z",
-            "content": "notExpired"
-          },
-          "instrumentClusterTime": {
-            "timestamp": "2022-02-22T20:00:22Z",
-            "content": "2022-02-22T20:00:22Z"
-          }
-        },
-        {
-          "timerID": "2",
-          "timerExpiredStatus": {
-            "timestamp": "2022-02-22T20:00:22Z",
-            "content": "notExpired"
-          },
-          "instrumentClusterTime": {
-            "timestamp": "2022-02-22T20:00:22Z",
-            "content": "2022-02-22T20:00:22Z"
-          }
-        },
-        {
-          "timerID": "3",
-          "timerExpiredStatus": {
-            "timestamp": "2022-02-22T20:00:22Z",
-            "content": "notExpired"
-          },
-          "instrumentClusterTime": {
-            "timestamp": "2022-02-22T20:00:22Z",
-            "content": "2022-02-22T20:00:22Z"
-          }
-        }
-      ]
+      "timer": []
     }
   }
 }

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -41,7 +41,7 @@ async def test_set_timer():
         connection = vw_connection.Connection(session, username, password)
         await connection.doLogin()
         data = TimerData({}, {})
-        await connection.setSchedule(vin=vin, data=data)
+        await connection.setTimersAndProfiles(vin=vin, data=data)
 
         assert 1 == 1
 

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -34,6 +34,7 @@ async def test_successful_login():
     username is None or password is None, reason="Username or password is not set. Check credentials.py.sample"
 )
 @pytest.mark.asyncio
+@pytest.skip("Not sure if this is even a good idea...")
 async def test_set_timer():
     """Test that login succeeds."""
     async with ClientSession() as session:

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -34,6 +34,21 @@ async def test_successful_login():
     username is None or password is None, reason="Username or password is not set. Check credentials.py.sample"
 )
 @pytest.mark.asyncio
+async def test_set_timer():
+    """Test that login succeeds."""
+    async with ClientSession() as session:
+        connection = vw_connection.Connection(session, username, password)
+        await connection.doLogin()
+        data = {}
+        await connection.setSchedule(vin=vin, data=data)
+
+        assert 1 == 1
+
+
+@pytest.mark.skipif(
+    username is None or password is None, reason="Username or password is not set. Check credentials.py.sample"
+)
+@pytest.mark.asyncio
 @skip("Not yet implemented")
 async def test_spin_action():
     """

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -5,12 +5,12 @@ These tests use actual credentials, and should thus be used with care.
 Credentials have to be specified in credentials.py.
 """
 import logging
-from unittest import skip
 
 import pytest
 from aiohttp import ClientSession
 
 from volkswagencarnet import vw_connection
+from volkswagencarnet.vw_timer import TimerData
 
 try:
     from credentials import username, password, spin, vin
@@ -34,13 +34,13 @@ async def test_successful_login():
     username is None or password is None, reason="Username or password is not set. Check credentials.py.sample"
 )
 @pytest.mark.asyncio
-@pytest.skip("Not sure if this is even a good idea...")
+@pytest.mark.skip("Not sure if this is even a good idea...")
 async def test_set_timer():
     """Test that login succeeds."""
     async with ClientSession() as session:
         connection = vw_connection.Connection(session, username, password)
         await connection.doLogin()
-        data = {}
+        data = TimerData({}, {})
         await connection.setSchedule(vin=vin, data=data)
 
         assert 1 == 1
@@ -50,7 +50,7 @@ async def test_set_timer():
     username is None or password is None, reason="Username or password is not set. Check credentials.py.sample"
 )
 @pytest.mark.asyncio
-@skip("Not yet implemented")
+@pytest.mark.skip("Not yet implemented")
 async def test_spin_action():
     """
     Test something that uses s-pin.

--- a/tests/vw_connection_test.py
+++ b/tests/vw_connection_test.py
@@ -121,3 +121,11 @@ Supported sensors:
  - Request in progress (domain:binary_sensor) - Off
 """
         )
+
+
+class SendCommandsTest(IsolatedAsyncioTestCase):
+    """Test command sending."""
+
+    async def test_set_schedule(self):
+        """Test set schedule."""
+        pass

--- a/tests/vw_timer_test.py
+++ b/tests/vw_timer_test.py
@@ -50,7 +50,54 @@ class TimerTest(TestCase):
         }
     }
 
+    data_updated = {
+        "timer": {
+            "timersAndProfiles": {
+                "timerProfileList": {
+                    "timerProfile": [
+                        {
+                            "profileName": "Profile 1",
+                            "profileID": "1",
+                            "operationCharging": True,
+                            "operationClimatisation": False,
+                            "targetChargeLevel": "75",
+                            "nightRateActive": True,
+                            "nightRateTimeStart": "21:00",
+                            "nightRateTimeEnd": "05:00",
+                            "chargeMaxCurrent": "10",
+                        }
+                    ]
+                },
+                "timerList": {
+                    "timer": [
+                        {
+                            "timestamp": "2022-02-22T20:00:22Z",
+                            "timerID": "3",
+                            "profileID": "3",
+                            "timerProgrammedStatus": "programmed",
+                            "timerFrequency": "cyclic",
+                            "departureTimeOfDay": "07:55",
+                            "departureWeekdayMask": "nnnnnyn",
+                        },
+                    ]
+                },
+                "timerBasicSetting": {
+                    "chargeMinLimit": "20",
+                    "targetTemperature": "2955",
+                },
+            },
+            "status": {"timer": []},
+        }
+    }
+
     def test_timer_serialization(self):
-        """Test de- ans serialization of timers."""
+        """Test de- and serialization of timers."""
         timer = TimerData(**self.data["timer"])
-        self.assertEqual(self.data, loads(timer.json))
+        self.assertEqual(self.data, timer.json)
+        self.assertNotEqual(timer.json, timer.json_updated)
+
+    def test_update_serialization(self):
+        timer = TimerData(**self.data["timer"])
+        timer.get_schedule(3).enable()
+        self.assertTrue(timer.get_schedule(3)._changed)
+        self.assertEqual(self.data_updated, timer.json_updated)

--- a/tests/vw_timer_test.py
+++ b/tests/vw_timer_test.py
@@ -36,6 +36,7 @@ class TimerTest(TestCase):
                             "timerFrequency": "cyclic",
                             "departureTimeOfDay": "07:55",
                             "departureWeekdayMask": "nnnnnyn",
+                            "currentCalendarProvider": {},
                         },
                     ]
                 },
@@ -70,13 +71,14 @@ class TimerTest(TestCase):
                 "timerList": {
                     "timer": [
                         {
-                            "timestamp": "2022-02-22T20:00:22Z",
+                            # "timestamp": "2022-02-22T20:00:22Z",
                             "timerID": "3",
                             "profileID": "3",
                             "timerProgrammedStatus": "programmed",
                             "timerFrequency": "cyclic",
                             "departureTimeOfDay": "07:55",
                             "departureWeekdayMask": "nnnnnyn",
+                            "currentCalendarProvider": {},
                         },
                     ]
                 },

--- a/tests/vw_timer_test.py
+++ b/tests/vw_timer_test.py
@@ -1,5 +1,4 @@
 """Depature timer tests."""
-from json import loads
 from unittest import TestCase
 
 from volkswagencarnet.vw_timer import TimerData
@@ -42,8 +41,8 @@ class TimerTest(TestCase):
                 },
                 "timerBasicSetting": {
                     "timestamp": "2022-02-22T20:00:22Z",
-                    "chargeMinLimit": "20",
-                    "targetTemperature": "2955",
+                    "chargeMinLimit": 20,
+                    "targetTemperature": 2955,
                 },
             },
             "status": {"timer": []},
@@ -82,8 +81,8 @@ class TimerTest(TestCase):
                     ]
                 },
                 "timerBasicSetting": {
-                    "chargeMinLimit": "20",
-                    "targetTemperature": "2955",
+                    "chargeMinLimit": 20,
+                    "targetTemperature": 2955,
                 },
             },
             "status": {"timer": []},
@@ -97,6 +96,7 @@ class TimerTest(TestCase):
         self.assertNotEqual(timer.json, timer.json_updated)
 
     def test_update_serialization(self):
+        """Check that updating a timer sets correct attributes."""
         timer = TimerData(**self.data["timer"])
         timer.get_schedule(3).enable()
         self.assertTrue(timer.get_schedule(3)._changed)

--- a/tests/vw_timer_test.py
+++ b/tests/vw_timer_test.py
@@ -1,7 +1,7 @@
 """Depature timer tests."""
 from unittest import TestCase
 
-from volkswagencarnet.vw_timer import TimerData
+from volkswagencarnet.vw_timer import TimerData, TimerProfile
 
 
 class TimerTest(TestCase):
@@ -103,3 +103,31 @@ class TimerTest(TestCase):
         timer.get_schedule(3).enable()
         self.assertTrue(timer.get_schedule(3)._changed)
         self.assertEqual(self.data_updated, timer.json_updated)
+
+    def test_get_profile(self):
+        """Test profile getter."""
+        timer = TimerData(**self.data["timer"])
+        self.assertIsNone(timer.get_profile(42))
+        self.assertIsNone(timer.get_profile("42"))
+
+        profile = timer.get_profile(1)
+        self.assertIsInstance(profile, TimerProfile)
+
+        self.assertEqual("21:00", profile.nightRateTimeStart)
+
+    def test_update_profile(self):
+        """Test updating profiles."""
+        timer = TimerData(**self.data["timer"])
+        profile = timer.get_profile(1)
+
+        self.assertNotEqual("unit test profile 42", profile.profileName)
+        profile.profileName = "unit test profile 42"
+
+        timer.update_profile(profile)
+
+        profile = timer.get_profile(1)
+
+        self.assertEqual("unit test profile 42", profile.profileName)
+
+        profile.profileID = 42
+        self.assertRaises(Exception, timer.update_profile(profile))

--- a/tests/vw_timer_test.py
+++ b/tests/vw_timer_test.py
@@ -1,0 +1,56 @@
+"""Depature timer tests."""
+from json import loads
+from unittest import TestCase
+
+from volkswagencarnet.vw_timer import TimerData
+
+
+class TimerTest(TestCase):
+    """Top level tests."""
+
+    data = {
+        "timer": {
+            "timersAndProfiles": {
+                "timerProfileList": {
+                    "timerProfile": [
+                        {
+                            "timestamp": "2022-02-22T20:00:22Z",
+                            "profileName": "Profile 1",
+                            "profileID": "1",
+                            "operationCharging": True,
+                            "operationClimatisation": False,
+                            "targetChargeLevel": "75",
+                            "nightRateActive": True,
+                            "nightRateTimeStart": "21:00",
+                            "nightRateTimeEnd": "05:00",
+                            "chargeMaxCurrent": "10",
+                        }
+                    ]
+                },
+                "timerList": {
+                    "timer": [
+                        {
+                            "timestamp": "2022-02-22T20:00:22Z",
+                            "timerID": "3",
+                            "profileID": "3",
+                            "timerProgrammedStatus": "notProgrammed",
+                            "timerFrequency": "cyclic",
+                            "departureTimeOfDay": "07:55",
+                            "departureWeekdayMask": "nnnnnyn",
+                        },
+                    ]
+                },
+                "timerBasicSetting": {
+                    "timestamp": "2022-02-22T20:00:22Z",
+                    "chargeMinLimit": "20",
+                    "targetTemperature": "2955",
+                },
+            },
+            "status": {"timer": []},
+        }
+    }
+
+    def test_timer_serialization(self):
+        """Test de- ans serialization of timers."""
+        timer = TimerData(**self.data["timer"])
+        self.assertEqual(self.data, loads(timer.json))

--- a/tests/vw_timer_test.py
+++ b/tests/vw_timer_test.py
@@ -44,6 +44,7 @@ class TimerTest(TestCase):
                     "timestamp": "2022-02-22T20:00:22Z",
                     "chargeMinLimit": 20,
                     "targetTemperature": 2955,
+                    "heaterSource": None,
                 },
             },
             "status": {"timer": []},

--- a/tests/vw_utilities_test.py
+++ b/tests/vw_utilities_test.py
@@ -4,7 +4,18 @@ from json import JSONDecodeError
 from unittest import TestCase, mock
 from unittest.mock import DEFAULT
 
-from volkswagencarnet.vw_utilities import camel2slug, is_valid_path, obj_parser, json_loads, read_config, make_url
+from volkswagencarnet.vw_utilities import (
+    camel2slug,
+    is_valid_path,
+    obj_parser,
+    json_loads,
+    read_config,
+    make_url,
+    fahrenheit_to_vw,
+    vw_to_celsius,
+    vw_to_fahrenheit,
+    celsius_to_vw,
+)
 
 
 class UtilitiesTest(TestCase):
@@ -130,3 +141,27 @@ baz
         """Test placeholder replacements."""
         self.assertEqual("foo/2/baz", make_url("foo/{bar}/baz{baz}", bar=2, baz=""))
         self.assertEqual("foo/asd/2", make_url("foo/{baz}/$bar", bar=2, baz="asd"))
+
+    def test_celcius_to_vw(self):
+        """Test Celsius conversion."""
+        self.assertEqual(2730, celsius_to_vw(0))
+        self.assertEqual(2955, celsius_to_vw(22.4))
+        self.assertEqual(2960, celsius_to_vw(22.7))
+
+    def test_fahrenheit_to_vw(self):
+        """Test Fahrenheit conversion."""
+        self.assertEqual(2730, fahrenheit_to_vw(32))
+        self.assertEqual(2955, fahrenheit_to_vw(72.3))
+        self.assertEqual(2960, fahrenheit_to_vw(72.9))
+
+    def test_vw_to_celcius(self):
+        """Test Celsius conversion."""
+        self.assertEqual(0, vw_to_celsius(2730))
+        self.assertEqual(22.5, vw_to_celsius(2955))
+        self.assertEqual(23, vw_to_celsius(2960))
+
+    def test_vw_to_fahrenheit(self):
+        """Test Fahrenheit conversion."""
+        self.assertEqual(32, vw_to_fahrenheit(2730))
+        self.assertEqual(72, vw_to_fahrenheit(2955))
+        self.assertEqual(73, vw_to_fahrenheit(2960))

--- a/tests/vw_utilities_test.py
+++ b/tests/vw_utilities_test.py
@@ -4,7 +4,7 @@ from json import JSONDecodeError
 from unittest import TestCase, mock
 from unittest.mock import DEFAULT
 
-from volkswagencarnet.vw_utilities import camel2slug, is_valid_path, obj_parser, json_loads, read_config
+from volkswagencarnet.vw_utilities import camel2slug, is_valid_path, obj_parser, json_loads, read_config, make_url
 
 
 class UtilitiesTest(TestCase):
@@ -125,3 +125,8 @@ baz
         mock_open.side_effect = IOError
         with mock.patch("builtins.open", mock_open):
             self.assertEqual({}, read_config())
+
+    def test_make_url(self):
+        """Test placeholder replacements."""
+        self.assertEqual("foo/2/baz", make_url("foo/{bar}/baz{baz}", bar=2, baz=""))
+        self.assertEqual("foo/asd/2", make_url("foo/{baz}/$bar", bar=2, baz="asd"))

--- a/tests/vw_vehicle_test.py
+++ b/tests/vw_vehicle_test.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import pytest
 
 from .fixtures.connection import TimersConnection
-from .fixtures.constants import status_report_json_file, MOCK_VIN
+from .fixtures.constants import status_report_json_file, MOCK_VIN, timers_json_file
 from volkswagencarnet.vw_utilities import json_loads
 
 if sys.version_info >= (3, 8):
@@ -83,6 +83,19 @@ class VehicleTest(IsolatedAsyncioTestCase):
         """Test the discovery process."""
         pass
 
+    @pytest.mark.asyncio
+    async def test_get_timerprogramming(self):
+        """Vehicle with timers loaded."""
+        vehicle = Vehicle(conn=TimersConnection(None), url=MOCK_VIN)
+        vehicle._discovered = True
+
+        with patch.dict(vehicle._services, {"timerprogramming_v1": {"active": True}}), patch.dict(
+            vehicle._states, {"timer": None}
+        ):
+            await vehicle.get_timerprogramming()
+            self.assertIn("timer", vehicle._states)
+            self.assertIn("timersAndProfiles", vehicle._states["timer"])
+
     async def test_update_deactivated(self):
         """Test that calling update on a deactivated Vehicle does nothing."""
         vehicle = MagicMock(spec=Vehicle, name="MockDeactivatedVehicle")
@@ -152,6 +165,87 @@ class VehiclePropertyTest(IsolatedAsyncioTestCase):
             res = vehicle.is_last_connected_supported
             self.assertTrue(res, "Last connected supported returned False when it should have been True")
 
+    async def test_get_schedule1(self):
+        """Test that schedule 1 support works."""
+        vehicle = Vehicle(conn=TimersConnection(None), url=MOCK_VIN)
+        vehicle._discovered = True
+
+        with open(timers_json_file) as f:
+            data = json_loads(f.read())
+        with patch.dict(vehicle._services, {"timerprogramming_v1": {"active": True}}), patch.dict(
+            vehicle._states, data
+        ):
+            self.assertTrue(vehicle.is_schedule1_supported)
+            self.assertDictEqual(
+                {
+                    "timestamp": datetime.fromisoformat("2022-02-22T20:00:22+00:00"),
+                    "profileName": "Profile 1",
+                    "profileID": "1",
+                    "operationCharging": True,
+                    "operationClimatisation": False,
+                    "targetChargeLevel": "75",
+                    "nightRateActive": True,
+                    "nightRateTimeStart": "21:00",
+                    "nightRateTimeEnd": "05:00",
+                    "chargeMaxCurrent": "10",
+                },
+                vehicle.schedule1,
+            )
+
+    async def test_get_schedule2(self):
+        """Test that schedule 2 support works."""
+        vehicle = Vehicle(conn=TimersConnection(None), url=MOCK_VIN)
+        vehicle._discovered = True
+
+        with open(timers_json_file) as f:
+            data = json_loads(f.read())
+        with patch.dict(vehicle._services, {"timerprogramming_v1": {"active": True}}), patch.dict(
+            vehicle._states, data
+        ):
+            self.assertTrue(vehicle.is_schedule2_supported)
+            self.assertDictEqual(
+                {
+                    "timestamp": datetime.fromisoformat("2022-02-22T20:00:22+00:00"),
+                    "profileName": "Profile 2",
+                    "profileID": "2",
+                    "operationCharging": True,
+                    "operationClimatisation": True,
+                    "targetChargeLevel": "100",
+                    "nightRateActive": True,
+                    "nightRateTimeStart": "20:00",
+                    "nightRateTimeEnd": "05:00",
+                    "chargeMaxCurrent": "10",
+                },
+                vehicle.schedule2,
+            )
+
+    async def test_get_schedule3(self):
+        """Test that schedule 3 support works."""
+        vehicle = Vehicle(conn=TimersConnection(None), url=MOCK_VIN)
+        vehicle._discovered = True
+
+        with open(timers_json_file) as f:
+            data = json_loads(f.read())
+        with patch.dict(vehicle._services, {"timerprogramming_v1": {"active": True}}), patch.dict(
+            vehicle._states, data
+        ):
+            self.assertTrue(vehicle.is_schedule3_supported)
+            self.assertDictEqual(
+                {
+                    "timestamp": datetime.fromisoformat("2022-02-22T20:00:22+00:00"),
+                    "profileName": "Profile 3",
+                    "profileID": "3",
+                    "operationCharging": True,
+                    "operationClimatisation": False,
+                    "targetChargeLevel": "60",
+                    "nightRateActive": False,
+                    "nightRateTimeStart": "00:00",
+                    "nightRateTimeEnd": "00:00",
+                    "chargeMaxCurrent": "10",
+                },
+                vehicle.schedule3,
+            )
+
     async def test_last_connected(self):
         """
         Test that parsing last connected works.
@@ -189,19 +283,6 @@ class VehiclePropertyTest(IsolatedAsyncioTestCase):
                 self.assertEqual(99, vehicle.requests_remaining)
                 # attribute should be removed once read
                 self.assertNotIn("rate_limit_remaining", vehicle.attrs)
-
-    @pytest.mark.asyncio
-    async def test_get_timerprogramming(self):
-        """Vehicle with timers loaded."""
-        vehicle = Vehicle(conn=TimersConnection(None), url=MOCK_VIN)
-        vehicle._discovered = True
-
-        with patch.dict(vehicle._services, {"timerprogramming_v1": {"active": True}}), patch.dict(
-            vehicle._states, {"timer": None}
-        ):
-            await vehicle.get_timerprogramming()
-            self.assertIn("timer", vehicle._states)
-            self.assertIn("timersAndProfiles", vehicle._states["timer"])
 
     async def test_json(self):
         """Test JSON serialization of dict containing datetime."""

--- a/volkswagencarnet/vw_connection.py
+++ b/volkswagencarnet/vw_connection.py
@@ -1073,7 +1073,6 @@ class Connection:
         try:
             await self.set_token("vwg")
             response = await self.dataCall(
-                # f"fs-car/bs/departuretimer/v1/{BRAND}/{self._session_country}/vehicles/$vin/action",
                 f"fs-car/bs/departuretimer/v1/{BRAND}/{self._session_country}/vehicles/$vin/timer/actions",
                 vin=vin,
                 json={

--- a/volkswagencarnet/vw_connection.py
+++ b/volkswagencarnet/vw_connection.py
@@ -1076,7 +1076,7 @@ class Connection:
                 # f"fs-car/bs/departuretimer/v1/{BRAND}/{self._session_country}/vehicles/$vin/action",
                 f"fs-car/bs/departuretimer/v1/{BRAND}/{self._session_country}/vehicles/$vin/timer/actions",
                 vin=vin,
-                data={
+                json={
                     "action": {
                         "timersAndProfiles": data.timersAndProfiles.json_updated["timer"],
                         "type": "setTimersAndProfiles",

--- a/volkswagencarnet/vw_connection.py
+++ b/volkswagencarnet/vw_connection.py
@@ -1066,6 +1066,35 @@ class Connection:
                 self._session_headers["Content-Type"] = content_type
             raise
 
+    async def setSchedule(self, vin, data):
+        """Set schedules."""
+        try:
+            await self.set_token("vwg")
+            while True:
+                response = await self.get(
+                    f"fs-car/bs/departuretimer/v1/{BRAND}/{self._session_country}/vehicles/$vin",
+                )
+
+            raise Exception("FFFFUUUU")
+
+            self._session_headers.pop("X-securityToken", None)
+            if not response:
+                raise Exception("Invalid or no response")
+            elif response == 429:
+                return dict({"id": None, "state": "Throttled", "rate_limit_remaining": 0})
+            else:
+                request_id = response.get("action", {}).get("actionId", 0)
+                request_state = response.get("action", {}).get("actionState", "unknown")
+                remaining = response.get("rate_limit_remaining", -1)
+                _LOGGER.debug(
+                    f'Request for climater action returned with state "{request_state}", request id: {request_id},'
+                    f" remaining requests: {remaining}"
+                )
+                return dict({"id": str(request_id), "state": request_state, "rate_limit_remaining": remaining})
+        except:
+            self._session_headers.pop("X-securityToken", None)
+            raise
+
     async def setLock(self, vin, data, spin):
         """Remote lock and unlock actions."""
         content_type = None

--- a/volkswagencarnet/vw_dashboard.py
+++ b/volkswagencarnet/vw_dashboard.py
@@ -522,7 +522,7 @@ class DepartureTimer(Switch):
     async def turn_on(self):
         schedule: TimerData = self.vehicle.attrs["timer"]
         schedule.get_schedule(self._id).enable()
-        await self.vehicle.set_schedule(self._id, schedule)
+        await self.vehicle.set_schedule(schedule)
         await self.vehicle.update()
 
     async def turn_off(self):
@@ -539,7 +539,7 @@ class DepartureTimer(Switch):
     def attributes(self):
         s: Timer = self.vehicle.schedule(self._id)
         return dict(
-            last_result="FIXME",
+            # last_result="FIXME",
             profile_id=s.profileID,
             last_updated=s.timestamp,
             timer_id=s.timerID,
@@ -944,6 +944,7 @@ def create_instruments():
 
 class Dashboard:
     """Helper for accessing the instruments."""
+
     def __init__(self, vehicle, **config):
         """Initialize instruments."""
         _LOGGER.debug("Setting up dashboard with config :%s", config)

--- a/volkswagencarnet/vw_dashboard.py
+++ b/volkswagencarnet/vw_dashboard.py
@@ -696,7 +696,7 @@ class ChargeMinLevel(Sensor):
         super().__init__(
             attr="schedule_min_charge_level",
             name="Minimum charge level for departure timers",
-            icon="mdi:battery-arrow-up",
+            icon="mdi:battery-arrow-down",
             unit="%",
         )
 

--- a/volkswagencarnet/vw_timer.py
+++ b/volkswagencarnet/vw_timer.py
@@ -4,6 +4,8 @@ import logging
 from datetime import datetime
 from typing import Union, List, Optional, Dict
 
+from volkswagencarnet.vw_utilities import celsius_to_vw, fahrenheit_to_vw, vw_to_celsius
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -68,13 +70,27 @@ class BasicSettings(DepartureTimerClass):
     def __init__(self, timestamp: str, chargeMinLimit: Union[str, int], targetTemperature: Union[str, int]):
         """Init."""
         self.timestamp = timestamp
-        self.chargeMinLimit = int(chargeMinLimit)
-        self.targetTemperature = int(targetTemperature)
+        self.chargeMinLimit: int = int(chargeMinLimit)
+        self.targetTemperature: int = int(targetTemperature)
 
-    def set_target_temperature(self, temp: int):
+    @property
+    def target_temperature_celsius(self):
+        """Get target temperature in Celsius."""
+        return vw_to_celsius(self.targetTemperature)
+
+    def set_target_temperature_celsius(self, temp: float):
         """Set target temperature for departure timers with climatisation enabled."""
-        self.targetTemperature = temp
-        self._changed = True
+        new_temp = celsius_to_vw(temp)
+        if new_temp != self.targetTemperature:
+            self.targetTemperature = new_temp
+            self._changed = True
+
+    def set_target_temperature_fahrenheit(self, temp: float):
+        """Set target temperature for departure timers with climatisation enabled."""
+        new_temp = fahrenheit_to_vw(temp)
+        if new_temp != self.targetTemperature:
+            self.targetTemperature = new_temp
+            self._changed = True
 
     def set_charge_min_limit(self, limit: int):
         """Set the global minimum charge limit."""
@@ -183,7 +199,7 @@ class TimerProfileList(DepartureTimerClass):
 
 
 # noinspection PyPep8Naming
-class TimerAndProfiles(DepartureTimerClass):
+class TimersAndProfiles(DepartureTimerClass):
     """Timer and profile object."""
 
     def __init__(
@@ -206,13 +222,13 @@ class TimerAndProfiles(DepartureTimerClass):
 class TimerData(DepartureTimerClass):
     """Top level timer object."""
 
-    def __init__(self, timersAndProfiles: Union[Dict, TimerAndProfiles], status: Optional[dict]):
+    def __init__(self, timersAndProfiles: Union[Dict, TimersAndProfiles], status: Optional[dict]):
         """Init."""
         try:
             self.timersAndProfiles = (
                 timersAndProfiles
-                if isinstance(timersAndProfiles, TimerAndProfiles)
-                else TimerAndProfiles(**timersAndProfiles)
+                if isinstance(timersAndProfiles, TimersAndProfiles)
+                else TimersAndProfiles(**timersAndProfiles)
             )
             self.status = status
             self._valid = True

--- a/volkswagencarnet/vw_timer.py
+++ b/volkswagencarnet/vw_timer.py
@@ -41,12 +41,14 @@ class DepartureTimerClass:
             if i[0] != "_"
         }
         if issubclass(type(o), DepartureTimerClass) and hasattr(o, "timestamp"):
-            # if not o._changed:
-            del res["timestamp"]
+            res.pop("timestamp", None)
         # Remove any None valued keys
+        nones = []
         for k in res:
             if res[k] is None:
-                del res[k]
+                nones.append(k)
+        for k in nones:
+            res.pop(k, None)
         return res
 
     def serialize(self, o):
@@ -74,13 +76,13 @@ class BasicSettings(DepartureTimerClass):
     def __init__(
         self,
         timestamp: str,
-        chargeMinLimit: Union[str, int],
-        targetTemperature: Optional[Union[str, int]],
-        heaterSource: Optional[str],
+        chargeMinLimit: Union[str, int] = None,
+        targetTemperature: Optional[Union[str, int]] = None,
+        heaterSource: Optional[str] = None,
     ):
         """Init."""
         self.timestamp = timestamp
-        self.chargeMinLimit: int = int(chargeMinLimit)
+        self.chargeMinLimit: Optional[int] = int(chargeMinLimit) if chargeMinLimit is not None else None
         self.targetTemperature: Optional[int] = int(targetTemperature) if targetTemperature is not None else None
         self.heaterSource: Optional[str] = heaterSource
 

--- a/volkswagencarnet/vw_timer.py
+++ b/volkswagencarnet/vw_timer.py
@@ -39,8 +39,8 @@ class DepartureTimerClass:
             if i[0] != "_"
         }
         if issubclass(type(o), DepartureTimerClass) and hasattr(o, "timestamp"):
-            if not o._changed:
-                del res["timestamp"]
+            # if not o._changed:
+            del res["timestamp"]
         # Remove any None valued keys
         for k in res:
             if res[k] is None:
@@ -86,6 +86,7 @@ class Timer(DepartureTimerClass):
         departureTimeOfDay: str = None,
         departureWeekdayMask: str = None,
         departureDateTime: str = None,
+        **kw,
     ):
         """Init."""
         self.timestamp = timestamp
@@ -96,9 +97,13 @@ class Timer(DepartureTimerClass):
         # single timers have a specific date, cyclic have time and day mask
         if timerFrequency == "single":
             self.departureDateTime = departureDateTime
+            self.departureTimeOfDay = "00:00"
         else:
-            self.departureTimeOfDay = departureTimeOfDay
+            self.departureTimeOfDay = departureTimeOfDay if departureTimeOfDay else "00:00"
             self.departureWeekdayMask = departureWeekdayMask
+        self.currentCalendarProvider: dict = {}
+        for k in kw:
+            _LOGGER.debug(f"Timer: Got unhandled property {k} with value {kw[k]}")
 
     @property
     def enabled(self):

--- a/volkswagencarnet/vw_timer.py
+++ b/volkswagencarnet/vw_timer.py
@@ -1,0 +1,128 @@
+"""Class for departure timer basic settings."""
+import json
+from typing import Union, List
+
+
+# noinspection PyPep8Naming
+class BasicSettings:
+    """Basic settings."""
+
+    def __init__(self, timestamp: str, chargeMinLimit: str, targetTemperature: str):
+        """Init."""
+        self.timestamp = timestamp
+        self.chargeMinLimit = chargeMinLimit
+        self.targetTemperature = targetTemperature
+
+
+# noinspection PyPep8Naming
+class Timer:
+    """FIXME."""
+
+    def __init__(
+        self,
+        timestamp: str,
+        timerID: str,
+        profileID: str,
+        timerProgrammedStatus: str,
+        timerFrequency: str,
+        departureTimeOfDay: str,
+        departureWeekdayMask: str,
+    ):
+        """Init."""
+        self.timestamp = timestamp
+        self.timerID = timerID
+        self.profileID = profileID
+        self.timerProgrammedStatus = timerProgrammedStatus
+        self.timerFrequency = timerFrequency
+        self.departureTimeOfDay = departureTimeOfDay
+        self.departureWeekdayMask = departureWeekdayMask
+
+
+class TimerList:
+    """FIXME."""
+
+    def __init__(self, timer: List[Union[dict, Timer]]):
+        """Init."""
+        self.timer = []
+        for t in timer:
+            self.timer.append(t if isinstance(t, Timer) else Timer(**t))
+
+
+# noinspection PyPep8Naming
+class TimerProfile:
+    """Timer profile."""
+
+    def __init__(
+        self,
+        timestamp: str,
+        profileName: str,
+        profileID: str,
+        operationCharging: bool,
+        operationClimatisation: bool,
+        targetChargeLevel: str,
+        nightRateActive: bool,
+        nightRateTimeStart: str,
+        nightRateTimeEnd: str,
+        chargeMaxCurrent: str,
+    ):
+        """Init."""
+        self.timestamp = timestamp
+        self.profileName = profileName
+        self.profileID = profileID
+        self.operationCharging = operationCharging
+        self.operationClimatisation = operationClimatisation
+        self.targetChargeLevel = targetChargeLevel
+        self.nightRateActive = nightRateActive
+        self.nightRateTimeStart = nightRateTimeStart
+        self.nightRateTimeEnd = nightRateTimeEnd
+        self.chargeMaxCurrent = chargeMaxCurrent
+
+
+# noinspection PyPep8Naming
+class TimerProfileList:
+    """FIXME."""
+
+    def __init__(self, timerProfile: List[Union[dict, TimerProfile]]):
+        """Init."""
+        self.timerProfile = []
+        for p in timerProfile:
+            self.timerProfile.append(p if isinstance(p, TimerProfile) else TimerProfile(**p))
+
+
+# noinspection PyPep8Naming
+class TimerAndProfiles:
+    """Timer and profile object."""
+
+    def __init__(
+        self,
+        timerProfileList: Union[dict, TimerProfileList],
+        timerList: Union[dict, TimerList],
+        timerBasicSetting: Union[dict, BasicSettings],
+    ):
+        """Init."""
+        self.timerProfileList = (
+            timerProfileList if isinstance(timerProfileList, TimerProfileList) else TimerProfileList(**timerProfileList)
+        )
+        self.timerList = timerList if isinstance(timerList, TimerList) else TimerList(**timerList)
+        self.timerBasicSetting = (
+            timerBasicSetting if isinstance(timerBasicSetting, BasicSettings) else BasicSettings(**timerBasicSetting)
+        )
+
+
+# noinspection PyPep8Naming
+class TimerData:
+    """Top level timer object."""
+
+    def __init__(self, timersAndProfiles: Union[dict, TimerAndProfiles], status: dict):
+        """Init."""
+        self.timersAndProfiles = (
+            timersAndProfiles
+            if isinstance(timersAndProfiles, TimerAndProfiles)
+            else TimerAndProfiles(**timersAndProfiles)
+        )
+        self.status = status
+
+    @property
+    def json(self):
+        """Return JSON representation."""
+        return json.dumps({"timer": self}, default=lambda o: o.__dict__, indent=2)

--- a/volkswagencarnet/vw_timer.py
+++ b/volkswagencarnet/vw_timer.py
@@ -172,7 +172,7 @@ class TimerProfile(DepartureTimerClass):
         nightRateTimeStart: str,
         nightRateTimeEnd: str,
         chargeMaxCurrent: str,
-        profileName: str = "i-have-no-name",
+        profileName: str = "",
     ):
         """Init."""
         self.timestamp = timestamp

--- a/volkswagencarnet/vw_timer.py
+++ b/volkswagencarnet/vw_timer.py
@@ -245,6 +245,22 @@ class TimerData(DepartureTimerClass):
         """Check if timer exists by id."""
         return self._valid and any(p.timerID == str(schedule_id) for p in self.timersAndProfiles.timerList.timer)
 
-    def get_schedule(self, schedule_id: Union[str, int]):
+    def get_schedule(self, id: Union[str, int]):
         """Find timer by id."""
-        return next(filter(lambda p: p.timerID == str(schedule_id), self.timersAndProfiles.timerList.timer), None)
+        return next(filter(lambda p: p.timerID == str(id), self.timersAndProfiles.timerList.timer), None)
+
+    def get_profile(self, id: Union[str, int]):
+        """Find profile by id."""
+        return next(
+            filter(lambda p: p.profileID == str(id), self.timersAndProfiles.timerProfileList.timerProfile), None
+        )
+
+    def update_profile(self, profile: TimerProfile) -> None:
+        """Replace a profile with given input."""
+        for p in self.timersAndProfiles.timerProfileList.timerProfile:
+            if str(p.profileID) == str(profile.profileID):
+                # hackish way to update all properties, but easier than replacing
+                # the actual object
+                p.__dict__.update(profile.__dict__)
+                return
+        raise Exception("Profile not found")

--- a/volkswagencarnet/vw_timer.py
+++ b/volkswagencarnet/vw_timer.py
@@ -71,6 +71,16 @@ class BasicSettings(DepartureTimerClass):
         self.chargeMinLimit = int(chargeMinLimit)
         self.targetTemperature = int(targetTemperature)
 
+    def set_target_temperature(self, temp: int):
+        """Set target temperature for departure timers with climatisation enabled."""
+        self.targetTemperature = temp
+        self._changed = True
+
+    def set_charge_min_limit(self, limit: int):
+        """Set the global minimum charge limit."""
+        self.chargeMinLimit = limit
+        self._changed = True
+
 
 # noinspection PyPep8Naming
 class Timer(DepartureTimerClass):

--- a/volkswagencarnet/vw_utilities.py
+++ b/volkswagencarnet/vw_utilities.py
@@ -145,3 +145,25 @@ def make_url(url: str, **kwargs):
     if "{" in url or "}" in url:
         raise ValueError("Not all values were substituted")
     return url
+
+
+# TODO: is VW using 273.15 or 273? :)
+def celsius_to_vw(val: float) -> int:
+    """Convert Celsius to VW format."""
+    return int(5 * round(2 * (273.15 + val)))
+
+
+def fahrenheit_to_vw(val: float) -> int:
+    """Convert Fahrenheit to VW format."""
+    return int(5 * round(2 * (273.15 + (val - 32) * 5 / 9)))
+
+
+def vw_to_celsius(val: int) -> float:
+    """Convert Celsius to VW format."""
+    return round(2 * ((val / 10) - 273.15)) / 2
+
+
+# TODO: are F ints of floats?
+def vw_to_fahrenheit(val: int) -> int:
+    """Convert Fahrenheit to VW format."""
+    return int(round((val / 10 - 273.15) * 9 / 5 + 32))

--- a/volkswagencarnet/vw_utilities.py
+++ b/volkswagencarnet/vw_utilities.py
@@ -135,3 +135,13 @@ def camel2slug(s: str) -> str:
     Should not produce "__" in case input contains something like "Foo_Bar"
     """
     return re.sub("((?<!_)[A-Z])", "_\\1", s).lower().strip("_ \n\t\r")
+
+
+def make_url(url: str, **kwargs):
+    """Replace placeholders in URLs."""
+    for a in kwargs:
+        url = url.replace("{" + a + "}", str(kwargs[a]))
+        url = url.replace("$" + a, str(kwargs[a]))
+    if "{" in url or "}" in url:
+        raise ValueError("Not all values were substituted")
+    return url

--- a/volkswagencarnet/vw_vehicle.py
+++ b/volkswagencarnet/vw_vehicle.py
@@ -65,7 +65,10 @@ class Vehicle:
             "rbatterycharge_v1": {"active": False},
             "rhonk_v1": {"active": False},
             "carfinder_v1": {"active": False},
-            # 'timerprogramming_v1': {'active': False}, # Not yet implemented
+            "timerprogramming_v1": {"active": False},
+            # "jobs_v1": {"active": False},
+            # "owner_v1": {"active": False},
+            # vehicles_v1_cai, services_v1, vehicletelemetry_v1
         }
 
     # API get and set functions #
@@ -223,7 +226,7 @@ class Vehicle:
         else:
             self._requests.pop("charger", None)
 
-    async def get_timerprogramming(self):
+    async def get_timerprogramming(self) -> None:
         """Fetch timer data if function is enabled."""
         if self._services.get("timerprogramming_v1", {}).get("active", False):
             if not await self.expired("timerprogramming_v1"):

--- a/volkswagencarnet/vw_vehicle.py
+++ b/volkswagencarnet/vw_vehicle.py
@@ -234,7 +234,7 @@ class Vehicle:
             if not await self.expired("timerprogramming_v1"):
                 data = await self._connection.getTimers(self.vin)
                 if data:
-                    self._states.update({"timers": data})
+                    self._states.update({"timer": data})
                 else:
                     _LOGGER.debug("Could not fetch timers")
         else:
@@ -1772,14 +1772,17 @@ class Vehicle:
 
     @property
     def is_departure_timer1_supported(self) -> bool:
+        """Check if timer 1 is supported."""
         return self.is_schedule_supported(1)
 
     @property
     def is_departure_timer2_supported(self) -> bool:
+        """Check if timer 2is supported."""
         return self.is_schedule_supported(2)
 
     @property
     def is_departure_timer3_supported(self) -> bool:
+        """Check if timer 3 is supported."""
         return self.is_schedule_supported(3)
 
     def is_schedule_supported(self, id: Union[str, int]) -> bool:

--- a/volkswagencarnet/vw_vehicle.py
+++ b/volkswagencarnet/vw_vehicle.py
@@ -86,7 +86,7 @@ class Vehicle:
                 return True
         return False
 
-    async def _handle_response(self, response, topic: str, error_msg: Optional[str] = None):
+    async def _handle_response(self, response, topic: str, error_msg: Optional[str] = None) -> bool:
         """Handle errors in response and get requests remaining."""
         if not response:
             self._requests[topic] = {"status": "Failed"}
@@ -94,7 +94,7 @@ class Vehicle:
             raise Exception(error_msg if error_msg is not None else "Failed to perform {topic} action")
         else:
             remaining = response.get("rate_limit_remaining", -1)
-            if remaining >= 0:
+            if remaining != -1:
                 _LOGGER.info(f"{remaining} requests")
                 self._requests["remaining"] = remaining
             self._requests[topic] = {
@@ -517,7 +517,7 @@ class Vehicle:
             self._requests["refresh"] = {"status": "Exception"}
         raise Exception("Data refresh failed")
 
-    async def set_schedule(self, data: TimerData):
+    async def set_schedule(self, data: TimerData) -> bool:
         """Store schedule."""
         if not self._services.get("timerprogramming_v1", False):
             _LOGGER.info("Remote control of timer functions is not supported.")

--- a/volkswagencarnet/vw_vehicle.py
+++ b/volkswagencarnet/vw_vehicle.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta, timezone
 from json import dumps as to_json
 from typing import Optional, Union, Any, Dict
 
-from volkswagencarnet.vw_timer import TimerData, Timer
+from volkswagencarnet.vw_timer import TimerData, Timer, BasicSettings
 
 from .vw_utilities import find_path, is_valid_path
 
@@ -72,6 +72,43 @@ class Vehicle:
             # "owner_v1": {"active": False},
             # vehicles_v1_cai, services_v1, vehicletelemetry_v1
         }
+
+    def _in_progress(self, topic: str, unknown_offset: int = 0) -> bool:
+        """Check if request is already in progress."""
+        if self._requests[topic].get("id", False):
+            timestamp = self._requests.get(topic, {}).get(
+                "timestamp", datetime.now() - timedelta(minutes=unknown_offset)
+            )
+            if timestamp + timedelta(minutes=3) > datetime.now():
+                self._requests.get(topic, {}).pop("id")
+            else:
+                _LOGGER.info(f"Action ({topic}) already in progress")
+                return True
+        return False
+
+    async def _handle_response(self, response, topic: str, error_msg: Optional[str] = None):
+        """Handle errors in response and get requests remaining."""
+        if not response:
+            self._requests[topic] = {"status": "Failed"}
+            _LOGGER.error(error_msg if error_msg is not None else "Failed to perform {topic} action")
+            raise Exception(error_msg if error_msg is not None else "Failed to perform {topic} action")
+        else:
+            remaining = response.get("rate_limit_remaining", -1)
+            if remaining >= 0:
+                _LOGGER.info(f"{remaining} requests")
+                self._requests["remaining"] = remaining
+            self._requests[topic] = {
+                "timestamp": datetime.now(),
+                "status": response.get("state", "Unknown"),
+                "id": response.get("id", 0),
+            }
+            if response.get("state", None) == "Throttled":
+                status = "Throttled"
+                _LOGGER.warning(f"Request throttled ({topic}")
+            else:
+                status = await self.wait_for_request(topic, response.get("id", 0))
+            self._requests[topic] = {"status": status}
+        return True
 
     # API get and set functions #
     # Init and update vehicle data
@@ -141,7 +178,7 @@ class Vehicle:
 
     # Data collection functions
     async def get_realcardata(self):
-        """Fetch realcar data."""
+        """Fetch realcardata."""
         data = await self._connection.getRealCarData(self.vin)
         if data:
             self._states.update(data)
@@ -275,19 +312,35 @@ class Vehicle:
             _LOGGER.error("No charger support.")
             raise Exception("No charger support.")
 
+    async def set_charge_min_level(self, level: int):
+        """Set the desired minimum charge level for departure schedules."""
+        if self.is_schedule_min_charge_level_supported:
+            if (0 <= level <= 100) and level % 10 == 0:
+                if self._in_progress("departuretimer"):
+                    return False
+                try:
+                    self._requests["latest"] = "Departuretimer"
+                    response = await self._connection.setChargeMinLevel(self.vin, level)
+                    return await self._handle_response(
+                        response=response, topic="departuretimer", error_msg="Failed to set minimum charge level"
+                    )
+                except Exception as error:
+                    _LOGGER.warning(f"Failed to set minimum charge level - {error}")
+                    self._requests["departuretimer"] = {"status": "Exception"}
+                    raise Exception(f"Failed to set minimum charge level - {error}")
+            else:
+                raise Exception("Level must be 0, 10, ..., 100")
+        else:
+            _LOGGER.error("Cannot set minimum level")
+            raise Exception("Cannot set minimum level")
+
     async def set_charger(self, action):
         """Charging actions."""
         if not self._services.get("rbatterycharge_v1", False):
             _LOGGER.info("Remote start/stop of charger is not supported.")
             raise Exception("Remote start/stop of charger is not supported.")
-        if self._requests["batterycharge"].get("id", False):
-            timestamp = self._requests.get("batterycharge", {}).get("timestamp", datetime.now())
-            expired = datetime.now() - timedelta(minutes=3)
-            if expired > timestamp:
-                self._requests.get("batterycharge", {}).pop("id")
-            else:
-                _LOGGER.debug("Charging action already in progress")
-                return False
+        if self._in_progress("batterycharge"):
+            return False
         if action in ["start", "stop"]:
             data = {"action": {"type": action}}
         elif action.get("action", {}).get("type", "") == "setSettings":
@@ -298,23 +351,9 @@ class Vehicle:
         try:
             self._requests["latest"] = "Charger"
             response = await self._connection.setCharger(self.vin, data)
-            if not response:
-                self._requests["batterycharge"] = {"status": "Failed"}
-                _LOGGER.error(f"Failed to {action} charging")
-                raise Exception(f"Failed to {action} charging")
-            else:
-                self._requests["remaining"] = response.get("rate_limit_remaining", -1)
-                self._requests["batterycharge"] = {
-                    "timestamp": datetime.now(),
-                    "status": response.get("state", "Unknown"),
-                    "id": response.get("id", 0),
-                }
-                if response.get("state", None) == "Throttled":
-                    status = "Throttled"
-                else:
-                    status = await self.wait_for_request("batterycharge", response.get("id", 0))
-                self._requests["batterycharge"] = {"status": status}
-                return True
+            return await self._handle_response(
+                response=response, topic="batterycharge", error_msg=f"Failed to {action} charging"
+            )
         except Exception as error:
             _LOGGER.warning(f"Failed to {action} charging - {error}")
             self._requests["batterycharge"] = {"status": "Exception"}
@@ -327,6 +366,8 @@ class Vehicle:
             if 16 <= int(temperature) <= 30:
                 temp = int((temperature + 273) * 10)
                 data = {"action": {"settings": {"targetTemperature": temp}, "type": "setSettings"}}
+            elif 2885 <= int(temperature) <= 3030:
+                data = {"action": {"settings": {"targetTemperature": temperature}, "type": "setSettings"}}
             else:
                 _LOGGER.error(f"Set climatisation target temp to {temperature} is not supported.")
                 raise Exception(f"Set climatisation target temp to {temperature} is not supported.")
@@ -392,34 +433,14 @@ class Vehicle:
         if not self._services.get("rclima_v1", False):
             _LOGGER.info("Remote control of climatisation functions is not supported.")
             raise Exception("Remote control of climatisation functions is not supported.")
-        if self._requests["climatisation"].get("id", False):
-            timestamp = self._requests.get("climatisation", {}).get("timestamp", datetime.now())
-            expired = datetime.now() - timedelta(minutes=3)
-            if expired > timestamp:
-                self._requests.get("climatisation", {}).pop("id")
-            else:
-                _LOGGER.debug("A climatisation action is already in progress")
-                return False
+        if self._in_progress("climatisation"):
+            return False
         try:
             self._requests["latest"] = "Climatisation"
             response = await self._connection.setClimater(self.vin, data, spin)
-            if not response:
-                self._requests["climatisation"] = {"status": "Failed"}
-                _LOGGER.error("Failed to execute climatisation request")
-                raise Exception("Failed to execute climatisation request")
-            else:
-                self._requests["remaining"] = response.get("rate_limit_remaining", -1)
-                self._requests["climatisation"] = {
-                    "timestamp": datetime.now(),
-                    "status": response.get("state", "Unknown"),
-                    "id": response.get("id", 0),
-                }
-                if response.get("state", None) == "Throttled":
-                    status = "Throttled"
-                else:
-                    status = await self.wait_for_request("climatisation", response.get("id", 0))
-                self._requests["climatisation"] = {"status": status}
-                return True
+            return await self._handle_response(
+                response=response, topic="climatisation", error_msg="Failed to execute climatisation request"
+            )
         except Exception as error:
             _LOGGER.warning(f"Failed to execute climatisation request - {error}")
             self._requests["climatisation"] = {"status": "Exception"}
@@ -431,14 +452,8 @@ class Vehicle:
         if not self.is_pheater_heating_supported:
             _LOGGER.error("No parking heater support.")
             raise Exception("No parking heater support.")
-        if self._requests["preheater"].get("id", False):
-            timestamp = self._requests.get("preheater", {}).get("timestamp", datetime.now())
-            expired = datetime.now() - timedelta(minutes=3)
-            if expired > timestamp:
-                self._requests.get("preheater", {}).pop("id")
-            else:
-                _LOGGER.debug("A parking heater action is already in progress")
-                return False
+        if self._in_progress("preheater"):
+            return False
         if mode not in ["heating", "ventilation", "off"]:
             _LOGGER.error(f"{mode} is an invalid action for parking heater")
             raise Exception(f"{mode} is an invalid action for parking heater")
@@ -453,23 +468,9 @@ class Vehicle:
         try:
             self._requests["latest"] = "Preheater"
             response = await self._connection.setPreHeater(self.vin, data, spin)
-            if not response:
-                self._requests["preheater"] = {"status": "Failed"}
-                _LOGGER.error(f"Failed to set parking heater to {mode}")
-                raise Exception(f'setPreHeater returned "{response}"')
-            else:
-                self._requests["remaining"] = response.get("rate_limit_remaining", -1)
-                self._requests["preheater"] = {
-                    "timestamp": datetime.now(),
-                    "status": response.get("state", "Unknown"),
-                    "id": response.get("id", 0),
-                }
-                if response.get("state", None) == "Throttled":
-                    status = "Throttled"
-                else:
-                    status = await self.wait_for_request("rs", response.get("id", 0))
-                self._requests["preheater"] = {"status": status}
-                return True
+            return await self._handle_response(
+                response=response, topic="preheater", error_msg=f"Failed to set parking heater to {mode}"
+            )
         except Exception as error:
             _LOGGER.warning(f"Failed to set parking heater mode to {mode} - {error}")
             self._requests["preheater"] = {"status": "Exception"}
@@ -481,14 +482,8 @@ class Vehicle:
         if not self._services.get("rlu_v1", False):
             _LOGGER.info("Remote lock/unlock is not supported.")
             raise Exception("Remote lock/unlock is not supported.")
-        if self._requests["lock"].get("id", False):
-            timestamp = self._requests.get("lock", {}).get("timestamp", datetime.now() - timedelta(minutes=5))
-            expired = datetime.now() - timedelta(minutes=3)
-            if expired > timestamp:
-                self._requests.get("lock", {}).pop("id")
-            else:
-                _LOGGER.debug("A lock action is already in progress")
-                return False
+        if self._in_progress("lock", unknown_offset=-5):
+            return False
         if action in ["lock", "unlock"]:
             data = '<rluAction xmlns="http://audi.de/connect/rlu"><action>' + action + "</action></rluAction>"
         else:
@@ -497,23 +492,7 @@ class Vehicle:
         try:
             self._requests["latest"] = "Lock"
             response = await self._connection.setLock(self.vin, data, spin)
-            if not response:
-                self._requests["lock"] = {"status": "Failed"}
-                _LOGGER.error(f"Failed to {action} vehicle")
-                raise Exception(f"Failed to {action} vehicle")
-            else:
-                self._requests["remaining"] = response.get("rate_limit_remaining", -1)
-                self._requests["lock"] = {
-                    "timestamp": datetime.now(),
-                    "status": response.get("state", "Unknown"),
-                    "id": response.get("id", 0),
-                }
-                if response.get("state", None) == "Throttled":
-                    status = "Throttled"
-                else:
-                    status = await self.wait_for_request("rlu", response.get("id", 0))
-                self._requests["lock"] = {"status": status}
-                return True
+            return await self._handle_response(response=response, topic="lock", error_msg=f"Failed to {action} vehicle")
         except Exception as error:
             _LOGGER.warning(f"Failed to {action} vehicle - {error}")
             self._requests["lock"] = {"status": "Exception"}
@@ -525,34 +504,14 @@ class Vehicle:
         if not self._services.get("statusreport_v1", {}).get("active", False):
             _LOGGER.info("Data refresh is not supported.")
             raise Exception("Data refresh is not supported.")
-        if self._requests["refresh"].get("id", False):
-            timestamp = self._requests.get("refresh", {}).get("timestamp", datetime.now() - timedelta(minutes=5))
-            expired = datetime.now() - timedelta(minutes=3)
-            if expired > timestamp:
-                self._requests.get("refresh", {}).pop("id")
-            else:
-                _LOGGER.debug("A data refresh request is already in progress")
-                return False
+        if self._in_progress("refresh", unknown_offset=-5):
+            return False
         try:
             self._requests["latest"] = "Refresh"
             response = await self._connection.setRefresh(self.vin)
-            if not response:
-                _LOGGER.error("Failed to request vehicle update")
-                self._requests["refresh"] = {"status": "Failed"}
-                raise Exception("Failed to execute data refresh")
-            else:
-                self._requests["remaining"] = response.get("rate_limit_remaining", -1)
-                self._requests["refresh"] = {
-                    "timestamp": datetime.now(),
-                    "status": response.get("status", "Unknown"),
-                    "id": response.get("id", 0),
-                }
-                if response.get("state", None) == "Throttled":
-                    status = "Throttled"
-                else:
-                    status = await self.wait_for_request("vsr", response.get("id", 0))
-                self._requests["refresh"] = {"status": status}
-                return True
+            return await self._handle_response(
+                response=response, topic="refresh", error_msg="Failed to request vehicle update"
+            )
         except Exception as error:
             _LOGGER.warning(f"Failed to execute data refresh - {error}")
             self._requests["refresh"] = {"status": "Exception"}
@@ -563,34 +522,14 @@ class Vehicle:
         if not self._services.get("timerprogramming_v1", False):
             _LOGGER.info("Remote control of timer functions is not supported.")
             raise Exception("Remote control of timer functions is not supported.")
-        if self._requests["departuretimer"].get("id", False):
-            timestamp = self._requests.get("departuretimer", {}).get("timestamp", datetime.now())
-            expired = datetime.now() - timedelta(minutes=3)
-            if expired > timestamp:
-                self._requests.get("departuretimer", {}).pop("id")
-            else:
-                _LOGGER.debug("A timer action is already in progress")
-                return False
+        if self._in_progress("departuretimer"):
+            return False
         try:
             self._requests["latest"] = "Departuretimer"
-            response = await self._connection.setSchedule(self.vin, data)
-            if not response:
-                self._requests["departuretimer"] = {"status": "Failed"}
-                _LOGGER.error("Failed to execute timer request")
-                raise Exception("Failed to execute timer request")
-            else:
-                self._requests["remaining"] = response.get("rate_limit_remaining", -1)
-                self._requests["departuretimer"] = {
-                    "timestamp": datetime.now(),
-                    "status": response.get("state", "Unknown"),
-                    "id": response.get("id", 0),
-                }
-                if response.get("state", None) == "Throttled":
-                    status = "Throttled"
-                else:
-                    status = await self.wait_for_request("departuretimer", response.get("id", 0))
-                self._requests["departuretimer"] = {"status": status}
-                return True
+            response = await self._connection.setTimersAndProfiles(self.vin, data.timersAndProfiles)
+            return await self._handle_response(
+                response=response, topic="departuretimer", error_msg="Failed to execute timer request"
+            )
         except Exception as error:
             _LOGGER.warning(f"Failed to execute timer request - {error}")
             self._requests["timer"] = {"status": "Exception"}
@@ -1378,7 +1317,7 @@ class Vehicle:
 
     @property
     def is_window_heater_supported(self) -> bool:
-        """Return true if vehichle has heater."""
+        """Return true if vehicle has heater."""
         if self.is_electric_climatisation_supported:
             if self.attrs.get("climater", {}).get("status", {}).get("windowHeatingStatusData", {}).get(
                 "windowHeatingStateFront", {}
@@ -1426,7 +1365,7 @@ class Vehicle:
 
     @property
     def is_pheater_ventilation_supported(self) -> bool:
-        """Return true if vehichle has combustion climatisation."""
+        """Return true if vehicle has combustion climatisation."""
         return self.is_pheater_heating_supported
 
     @property
@@ -1439,7 +1378,7 @@ class Vehicle:
 
     @property
     def is_pheater_heating_supported(self) -> bool:
-        """Return true if vehichle has combustion engine heating."""
+        """Return true if vehicle has combustion engine heating."""
         return self.attrs.get("heating", {}).get("climatisationStateReport", {}).get("climatisationState", False)
 
     @property
@@ -1449,7 +1388,7 @@ class Vehicle:
 
     @property
     def is_pheater_status_supported(self) -> bool:
-        """Return true if vehichle has combustion engine heating/ventilation."""
+        """Return true if vehicle has combustion engine heating/ventilation."""
         return self.attrs.get("heating", {}).get("climatisationStateReport", {}).get("climatisationState", False)
 
     # Windows
@@ -1771,6 +1710,30 @@ class Vehicle:
         return timer.get_schedule(schedule_id)
 
     @property
+    def schedule_min_charge_level(self) -> int:
+        """Get charge minimum level."""
+        timer: TimerData = self.attrs.get("timer")
+        return timer.timersAndProfiles.timerBasicSetting.chargeMinLimit
+
+    @property
+    def is_schedule_min_charge_level_supported(self) -> bool:
+        """Check if charge minimum level is supported."""
+        timer: TimerData = self.attrs.get("timer", None)
+        return timer.timersAndProfiles.timerBasicSetting.chargeMinLimit is not None
+
+    @property
+    def timer_basic_settings(self) -> BasicSettings:
+        """Check if timer basic settings are supported."""
+        timer: TimerData = self.attrs.get("timer")
+        return timer.timersAndProfiles.timerBasicSetting
+
+    @property
+    def is_timer_basic_settings_supported(self) -> bool:
+        """Check if timer basic settings are supported."""
+        timer: TimerData = self.attrs.get("timer", None)
+        return timer.timersAndProfiles.timerBasicSetting is not None
+
+    @property
     def is_departure_timer1_supported(self) -> bool:
         """Check if timer 1 is supported."""
         return self.is_schedule_supported(1)
@@ -2082,7 +2045,7 @@ class Vehicle:
     @property
     def is_requests_remaining_supported(self):
         """
-        Return true if requests remaining is supperted.
+        Return true if requests remaining is supported.
 
         :return:
         """


### PR DESCRIPTION
Relates to https://github.com/robinostlund/homeassistant-volkswagencarnet/issues/352

## WIP
A little bit of a placeholder still, but goal is to implement some functionality for timer programming etc.

Some data is probably different, if there is an aux heater or something attached, so will probably ask for volunteers to provide API responses at some point :wink: 


### Timers
- [X] enable/disable departure timers (implemented as switches for now)
- [x] edit departure time
- [x] change location for timer (wishlist)
- [x] edit timer schedule: singe with exact datetime or cyclic with weekday mask and time

### Misc settings
- [x] change min charge limit

### Locations (wishlist)
The whole departure schedule request is sent on each call to the backend, so including any changes to the charging profiles will update them also
- [X] edit target charge level
- [X] charge/clima/both
- [X] set max charge current
- [X] enable/disable "off-peak"
- [X] set "off-peak" times
