### PR TITLE
Timerprogramming fixes

### DIFF
--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -41,7 +41,7 @@ async def test_set_timer():
         connection = vw_connection.Connection(session, username, password)
         await connection.doLogin()
         data = TimerData({}, {})
-        await connection.setTimersAndProfiles(vin=vin, data=data)
+        await connection.setTimersAndProfiles(vin=vin, data=data.timersAndProfiles)
 
         assert 1 == 1
 

--- a/tests/vw_timer_test.py
+++ b/tests/vw_timer_test.py
@@ -23,6 +23,7 @@ class TimerTest(TestCase):
                             "nightRateTimeStart": "21:00",
                             "nightRateTimeEnd": "05:00",
                             "chargeMaxCurrent": "10",
+                            "heaterSource": None,
                         }
                     ]
                 },

--- a/volkswagencarnet/vw_connection.py
+++ b/volkswagencarnet/vw_connection.py
@@ -1070,7 +1070,7 @@ class Connection:
         """Set schedules."""
         return await self._setDepartureTimer(vin, data, "setTimersAndProfiles")
 
-    async def setChargeMinLevel(self, vin, limit: int):
+    async def setChargeMinLevel(self, vin: str, limit: int):
         """Set schedules."""
         data: Optional[TimerData] = await self.getTimers(vin)
         if data is None:

--- a/volkswagencarnet/vw_dashboard.py
+++ b/volkswagencarnet/vw_dashboard.py
@@ -714,6 +714,12 @@ def create_instruments():
             unit="%",
         ),
         Sensor(
+            attr="schedule_heater_source",
+            name="Heater source for departure timers",
+            icon="mdi:radiator",
+            unit="",
+        ),
+        Sensor(
             attr="distance",
             name="Odometer",
             icon="mdi:speedometer",

--- a/volkswagencarnet/vw_dashboard.py
+++ b/volkswagencarnet/vw_dashboard.py
@@ -688,31 +688,6 @@ class RequestResults(Sensor):
         return dict(self.vehicle.request_results)
 
 
-class ChargeMinLevel(Sensor):
-    """Get minimum charge level."""
-
-    def __init__(self):
-        """Init."""
-        super().__init__(
-            attr="schedule_min_charge_level",
-            name="Minimum charge level for departure timers",
-            icon="mdi:battery-arrow-down",
-            unit="%",
-        )
-
-    @property
-    def state(self) -> Union[int, str]:
-        """Return the desired minimum charge level."""
-        if self.vehicle.is_timer_basic_settings_supported:
-            return self.vehicle.timer_basic_settings.chargeMinLimit
-        return "Unknown"
-
-    @property
-    def assumed_state(self):
-        """Don't assume anything about state."""
-        return False
-
-
 def create_instruments():
     return [
         Position(),
@@ -728,11 +703,16 @@ def create_instruments():
         # ElectricClimatisationClimate(),
         # CombustionClimatisationClimate(),
         Charging(),
-        ChargeMinLevel(),
         DepartureTimer(1),
         DepartureTimer(2),
         DepartureTimer(3),
         RequestResults(),
+        Sensor(
+            attr="schedule_min_charge_level",
+            name="Minimum charge level for departure timers",
+            icon="mdi:battery-arrow-down",
+            unit="%",
+        ),
         Sensor(
             attr="distance",
             name="Odometer",
@@ -949,7 +929,7 @@ def create_instruments():
         BinarySensor(attr="trunk_closed", name="Trunk closed", device_class="door", reverse_state=True),
         BinarySensor(attr="hood_closed", name="Hood closed", device_class="door", reverse_state=True),
         BinarySensor(
-            attr="charging_cable_connected", name="Charging cable connected", device_class="plug", reverse_state=True
+            attr="charging_cable_connected", name="Charging cable connected", device_class="plug", reverse_state=False
         ),
         BinarySensor(
             attr="charging_cable_locked", name="Charging cable locked", device_class="lock", reverse_state=True

--- a/volkswagencarnet/vw_timer.py
+++ b/volkswagencarnet/vw_timer.py
@@ -203,6 +203,7 @@ class TimerProfile(DepartureTimerClass):
         nightRateTimeEnd: str,
         chargeMaxCurrent: str,
         profileName: str = "",
+        heaterSource: Optional[str] = None,
     ):
         """Init."""
         self.timestamp = timestamp
@@ -215,6 +216,7 @@ class TimerProfile(DepartureTimerClass):
         self.nightRateTimeStart = nightRateTimeStart
         self.nightRateTimeEnd = nightRateTimeEnd
         self.chargeMaxCurrent = chargeMaxCurrent
+        self.heaterSource: Optional[str] = heaterSource
 
 
 # noinspection PyPep8Naming

--- a/volkswagencarnet/vw_timer.py
+++ b/volkswagencarnet/vw_timer.py
@@ -221,7 +221,7 @@ class TimerProfile(DepartureTimerClass):
 
 # noinspection PyPep8Naming
 class TimerProfileList(DepartureTimerClass):
-    """FIXME."""
+    """Holder for timers and profiles array."""
 
     def __init__(self, timerProfile: List[Union[dict, TimerProfile]]):
         """Init."""
@@ -254,7 +254,7 @@ class TimersAndProfiles(DepartureTimerClass):
 class TimerData(DepartureTimerClass):
     """Top level timer object."""
 
-    def __init__(self, timersAndProfiles: Union[Dict, TimersAndProfiles], status: Optional[dict]):
+    def __init__(self, timersAndProfiles: Union[Dict, TimersAndProfiles], status: Optional[dict] = None):
         """Init."""
         try:
             self.timersAndProfiles = (

--- a/volkswagencarnet/vw_vehicle.py
+++ b/volkswagencarnet/vw_vehicle.py
@@ -230,15 +230,15 @@ class Vehicle:
                 data = await self._connection.getPosition(self.vin)
                 if data:
                     # Reset requests remaining to 15 if parking time has been updated
-                    if data.get("findCarResponse", {}).get("parkingTimeUTC", False):
+                    if data.get("findCarResponse", {}).get("parkingTimeUTC", None) is not None:
                         try:
                             new_time = data.get("findCarResponse").get("parkingTimeUTC")
-                            old_time = self.attrs.get("findCarResponse").get("parkingTimeUTC")
-                            if new_time > old_time:
+                            old_time = self.attrs.get("findCarResponse", {}).get("parkingTimeUTC", None)
+                            if old_time is None or new_time > old_time:
                                 _LOGGER.debug(f"Detected new parking time: {new_time}")
                                 self.requests_remaining = 15
                         except Exception as e:
-                            _LOGGER.warning(e)
+                            _LOGGER.warning(f"Failed to parse parking time: {e}")
                     self._states.update(data)
                 else:
                     _LOGGER.debug("Could not fetch any positional data")
@@ -1710,7 +1710,7 @@ class Vehicle:
         return timer.get_schedule(schedule_id)
 
     @property
-    def schedule_min_charge_level(self) -> int:
+    def schedule_min_charge_level(self) -> Optional[int]:
         """Get charge minimum level."""
         timer: TimerData = self.attrs.get("timer")
         return timer.timersAndProfiles.timerBasicSetting.chargeMinLimit

--- a/volkswagencarnet/vw_vehicle.py
+++ b/volkswagencarnet/vw_vehicle.py
@@ -903,7 +903,7 @@ class Vehicle:
 
     @property
     def charging_cable_connected(self) -> bool:
-        """Return plug locked state."""
+        """Return plug connected state."""
         response = self.attrs.get("charger")["status"]["plugStatusData"]["plugState"].get("content", 0)
         return response == "connected"
 
@@ -1213,8 +1213,8 @@ class Vehicle:
     @property
     def outside_temperature(self) -> Union[float, bool]:  # FIXME should probably be Optional[float] instead
         """Return outside temperature."""
-        response = int(self.attrs.get("StoredVehicleDataResponseParsed")["0x0301020001"].get("value", 0))
-        if response:
+        response = int(self.attrs.get("StoredVehicleDataResponseParsed")["0x0301020001"].get("value", None))
+        if response is not None:
             return round(float((response / 10) - 273.15), 1)
         else:
             return False

--- a/volkswagencarnet/vw_vehicle.py
+++ b/volkswagencarnet/vw_vehicle.py
@@ -1722,6 +1722,18 @@ class Vehicle:
         return timer.timersAndProfiles.timerBasicSetting.chargeMinLimit is not None
 
     @property
+    def schedule_heater_source(self) -> Optional[str]:
+        """Get departure schedule heater source."""
+        timer: TimerData = self.attrs.get("timer")
+        return timer.timersAndProfiles.timerBasicSetting.heaterSource
+
+    @property
+    def is_schedule_heater_source_supported(self) -> bool:
+        """Check if departure timers heater source is supported."""
+        timer: TimerData = self.attrs.get("timer", None)
+        return timer.timersAndProfiles.timerBasicSetting.heaterSource is not None
+
+    @property
     def timer_basic_settings(self) -> BasicSettings:
         """Check if timer basic settings are supported."""
         timer: TimerData = self.attrs.get("timer")


### PR DESCRIPTION
Add support for heater source in departure timers.

Breaking change! "charging_cable_connected" now returns True for "connected" status