### PR TITLE
Support continuing without a refresh token

### DIFF
--- a/volkswagencarnet/vw_connection.py
+++ b/volkswagencarnet/vw_connection.py
@@ -977,7 +977,7 @@ class Connection:
         except:
             raise
 
-    async def setCharger(self, vin, data):
+    async def setCharger(self, vin, data) -> dict:
         """Start/Stop charger."""
         try:
             await self.set_token("vwg")

--- a/volkswagencarnet/vw_connection.py
+++ b/volkswagencarnet/vw_connection.py
@@ -342,9 +342,15 @@ class Connection:
                 url=token_url, headers=self._session_auth_headers, data=token_body, allow_redirects=False
             )
             if req.status != 200:
-                raise Exception("Token exchange failed")
-            # Save tokens as "identity", these are tokens representing the user
-            self._session_tokens[client] = await req.json()
+                error_content = await req.text()
+                _LOGGER.warning(
+                    f"Failed to get a refresh token, trying to continue without... {req.status} {error_content}"
+                )
+                # raise Exception(f"Token exchange failed: {req.status} {error_content}")
+                self._session_tokens[client] = token_body
+            else:
+                # Save tokens as "identity", these are tokens representing the user
+                self._session_tokens[client] = await req.json()
             if "error" in self._session_tokens[client]:
                 error_msg = self._session_tokens[client].get("error", "")
                 if "error_description" in self._session_tokens[client]:

--- a/volkswagencarnet/vw_vehicle.py
+++ b/volkswagencarnet/vw_vehicle.py
@@ -301,7 +301,7 @@ class Vehicle:
 
     # Data set functions
     # Charging (BATTERYCHARGE)
-    async def set_charger_current(self, value):
+    async def set_charger_current(self, value) -> bool:
         """Set charger current."""
         if self.is_charging_supported:
             if 1 <= int(value) <= 255:
@@ -353,7 +353,7 @@ class Vehicle:
     #             self._requests["departuretimer"] = {"status": "Exception"}
     #             raise Exception(f"Failed to set heater source - {error}")
 
-    async def set_charger(self, action):
+    async def set_charger(self, action) -> bool:
         """Charging actions."""
         if not self._services.get("rbatterycharge_v1", False):
             _LOGGER.info("Remote start/stop of charger is not supported.")


### PR DESCRIPTION
If the token exchange fails, we can still actually use the service with the short lived sessions