### PR TITLE
Fix window support detection

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: trailing-whitespace
 
   -   repo: https://github.com/psf/black
-      rev: '22.1.0'
+      rev: '22.10.0'
       hooks:
         - id: black
 

--- a/volkswagencarnet/vw_vehicle.py
+++ b/volkswagencarnet/vw_vehicle.py
@@ -1630,15 +1630,15 @@ class Vehicle:
     @property
     def windows_closed(self) -> bool:
         """
-        Return true if all windows are closed.
+        Return true if all supported windows are closed.
 
         :return:
         """
         return (
-            self.window_closed_left_front
-            and self.window_closed_left_back
-            and self.window_closed_right_front
-            and self.window_closed_right_back
+            (not self.is_window_closed_left_front_supported or self.window_closed_left_front)
+            and (not self.is_window_closed_left_back_supported or self.window_closed_left_back)
+            and (not self.is_window_closed_right_front_supported or self.window_closed_right_front)
+            and (not self.is_window_closed_right_back_supported or self.window_closed_right_back)
         )
 
     @property
@@ -1654,10 +1654,12 @@ class Vehicle:
     @property
     def is_windows_closed_supported(self) -> bool:
         """Return true if window state is supported."""
-        if self.attrs.get("StoredVehicleDataResponseParsed", False):
-            if "0x0301050001" in self.attrs.get("StoredVehicleDataResponseParsed"):
-                return True
-        return False
+        return (
+            self.is_window_closed_left_front_supported
+            or self.is_window_closed_left_back_supported
+            or self.is_window_closed_right_front_supported
+            or self.is_window_closed_right_back_supported
+        )
 
     @property
     def window_closed_left_front(self) -> bool:
@@ -1683,7 +1685,8 @@ class Vehicle:
     def is_window_closed_left_front_supported(self) -> bool:
         """Return true if window state is supported."""
         if self.attrs.get("StoredVehicleDataResponseParsed", False):
-            return "0x0301050001" in self.attrs.get("StoredVehicleDataResponseParsed")
+            if "0x0301050001" in self.attrs.get("StoredVehicleDataResponseParsed"):
+                return int(self.attrs.get("StoredVehicleDataResponseParsed")["0x0301050001"].get("value", 0)) != 0
         return False
 
     @property
@@ -1711,7 +1714,7 @@ class Vehicle:
         """Return true if window state is supported."""
         if self.attrs.get("StoredVehicleDataResponseParsed", False):
             if "0x0301050005" in self.attrs.get("StoredVehicleDataResponseParsed"):
-                return True
+                return int(self.attrs.get("StoredVehicleDataResponseParsed")["0x0301050005"].get("value", 0)) != 0
         return False
 
     @property
@@ -1739,7 +1742,7 @@ class Vehicle:
         """Return true if window state is supported."""
         if self.attrs.get("StoredVehicleDataResponseParsed", False):
             if "0x0301050003" in self.attrs.get("StoredVehicleDataResponseParsed"):
-                return True
+                return int(self.attrs.get("StoredVehicleDataResponseParsed")["0x0301050003"].get("value", 0)) != 0
         return False
 
     @property
@@ -1767,7 +1770,7 @@ class Vehicle:
         """Return true if window state is supported."""
         if self.attrs.get("StoredVehicleDataResponseParsed", False):
             if "0x0301050007" in self.attrs.get("StoredVehicleDataResponseParsed"):
-                return True
+                return int(self.attrs.get("StoredVehicleDataResponseParsed")["0x0301050007"].get("value", 0)) != 0
         return False
 
     @property


### PR DESCRIPTION
I have a car where the windows in the rear cannot be opened. The API returns a response with the hex codes included, but with the value set to 0 (as it also does for the sunroof). This PR changes the logic for windows to match the logic of the sunroof. 

Additionally, it changes the value for windows_closed to only reflect the status of the actual supported windows, not all windows and changes the corresponding is_windows_closed_supported so that this sensor is only supported if any window is actually supported.

I bumped the Black version in the hopes of being able to run the pre-commit hook as there was an error regarding `cannot import name '_unicodefun' from 'click'`, however the hook is now failing on `mypy` due to some existing code.