### PR TITLE
Sensor 'Charging time left' as number of minutes

### DIFF
--- a/volkswagencarnet/vw_dashboard.py
+++ b/volkswagencarnet/vw_dashboard.py
@@ -863,7 +863,8 @@ def create_instruments():
             attr="charging_time_left",
             name="Charging time left",
             icon="mdi:battery-charging-100",
-            unit="",
+            unit="min",
+            state_class=VWStateClass.MEASUREMENT,
         ),
         Sensor(
             attr="electric_range",

--- a/volkswagencarnet/vw_vehicle.py
+++ b/volkswagencarnet/vw_vehicle.py
@@ -1034,7 +1034,7 @@ class Vehicle:
         return False
 
     @property
-    def charging_time_left(self) -> int | str:  # FIXME, should probably be either one
+    def charging_time_left(self) -> int:
         """Return minutes to charging complete."""
         if self.external_power:
             minutes = (
@@ -1047,10 +1047,10 @@ class Vehicle:
             if minutes:
                 try:
                     if minutes == -1:
-                        return "00:00"
+                        return 0
                     if minutes == 65535:
-                        return "00:00"
-                    return "%02d:%02d" % divmod(minutes, 60)
+                        return 0
+                    return minutes
                 except Exception:
                     pass
         return 0


### PR DESCRIPTION
Integration to Home Assistant has problem with string representation of "Charging time left".
So I changed the value to integer and defined the unit.