### PR TITLE
Remove Duplicate Entries for Doors and Trunk Lock

### DIFF
--- a/volkswagencarnet/vw_dashboard.py
+++ b/volkswagencarnet/vw_dashboard.py
@@ -1001,9 +1001,6 @@ def create_instruments():
         ),
         BinarySensor(attr="door_locked", name="Doors locked", device_class=VWDeviceClass.LOCK, reverse_state=True),
         BinarySensor(
-            attr="door_locked_sensor", name="Doors locked", device_class=VWDeviceClass.LOCK, reverse_state=True
-        ),
-        BinarySensor(
             attr="door_closed_left_front",
             name="Door closed left front",
             device_class=VWDeviceClass.DOOR,
@@ -1032,9 +1029,6 @@ def create_instruments():
             icon="mdi:car-door",
         ),
         BinarySensor(attr="trunk_locked", name="Trunk locked", device_class=VWDeviceClass.LOCK, reverse_state=True),
-        BinarySensor(
-            attr="trunk_locked_sensor", name="Trunk locked", device_class=VWDeviceClass.LOCK, reverse_state=True
-        ),
         BinarySensor(attr="trunk_closed", name="Trunk closed", device_class=VWDeviceClass.DOOR, reverse_state=True),
         BinarySensor(attr="hood_closed", name="Hood closed", device_class=VWDeviceClass.DOOR, reverse_state=True),
         BinarySensor(

--- a/volkswagencarnet/vw_vehicle.py
+++ b/volkswagencarnet/vw_vehicle.py
@@ -1676,11 +1676,6 @@ class Vehicle:
 
     # Locks
     @property
-    def door_locked_sensor(self) -> bool:
-        """Return same state as lock entity, since they are mutually exclusive."""
-        return self.door_locked
-
-    @property
     def door_locked(self) -> bool:
         """
         Return true if all doors are locked.
@@ -1695,21 +1690,7 @@ class Vehicle:
         return find_path(self.attrs, "access.accessStatus.value.carCapturedTimestamp")
 
     @property
-    def door_locked_sensor_last_updated(self) -> datetime:
-        """Return door lock last updated."""
-        return find_path(self.attrs, "access.accessStatus.value.carCapturedTimestamp")
-
-    @property
     def is_door_locked_supported(self) -> bool:
-        """
-        Return true if supported.
-
-        :return:
-        """
-        return is_valid_path(self.attrs, "access.accessStatus.value.doorLockStatus")
-
-    @property
-    def is_door_locked_sensor_supported(self) -> bool:
         """
         Return true if supported.
 
@@ -1737,38 +1718,6 @@ class Vehicle:
 
     @property
     def is_trunk_locked_supported(self) -> bool:
-        """
-        Return true if supported.
-
-        :return:
-        """
-        if is_valid_path(self.attrs, "access.accessStatus.value.doors"):
-            doors = find_path(self.attrs, "access.accessStatus.value.doors")
-            for door in doors:
-                if door["name"] == "trunk" and "unsupported" not in door["status"]:
-                    return True
-        return False
-
-    @property
-    def trunk_locked_sensor(self) -> bool:
-        """
-        Return trunk locked state.
-
-        :return:
-        """
-        doors = find_path(self.attrs, "access.accessStatus.value.doors")
-        for door in doors:
-            if door["name"] == "trunk":
-                return "locked" in door["status"]
-        return False
-
-    @property
-    def trunk_locked_sensor_last_updated(self) -> datetime:
-        """Return attribute last updated timestamp."""
-        return find_path(self.attrs, "access.accessStatus.value.carCapturedTimestamp")
-
-    @property
-    def is_trunk_locked_sensor_supported(self) -> bool:
         """
         Return true if supported.
 


### PR DESCRIPTION
Remove Duplicate Entries for Doors and Trunk Locked Sensors.

This is how it looks before the fix:
![Screenshot 2023-11-29 at 23 45 28](https://github.com/robinostlund/volkswagencarnet/assets/630000/5cc67912-4226-4d06-a180-33ae5556224b)
