### PR TITLE
Fix the bug introduced with the clean-up commit 3c753a3

### DIFF
--- a/volkswagencarnet/vw_connection.py
+++ b/volkswagencarnet/vw_connection.py
@@ -416,7 +416,7 @@ class Connection:
                 return res
 
             if self._session_fulldebug:
-                _LOGGER.debug(f'Request for "{url}" returned with status code [{response.status}], response: {res.text}')
+                _LOGGER.debug(f'Request for "{url}" returned with status code [{response.status}], response: {res}')
             else:
                 _LOGGER.debug(f'Request for "{url}" returned with status code [{response.status}]')
             return res


### PR DESCRIPTION
Hi @oliverrahner,

There is a bug introducing the clean-up commit 3c753a3.

Once you adding integration and enables full debug log:
![Screenshot 2023-12-05 at 13 10 19](https://github.com/robinostlund/volkswagencarnet/assets/630000/94da8ac4-3975-4060-8e0d-61b04faf3ee4)

It's failing with the following error:
```
2023-12-05 12:44:20.412 INFO (MainThread) [volkswagencarnet.vw_connection] Successfully logged in
2023-12-05 12:44:20.412 DEBUG (MainThread) [volkswagencarnet.vw_connection] Fetching vehicles associated with account
2023-12-05 12:44:20.412 DEBUG (MainThread) [volkswagencarnet.vw_connection] HTTP GET "https://emea.bff.cariad.digital/vehicle/v2/vehicles"
2023-12-05 12:44:21.108 ERROR (MainThread) [custom_components.volkswagencarnet.config_flow] Failed to login due to error: 'dict' object has no attribute 'text'
```

This PR revert back the change being done in the clean-up commit.