### PR TITLE
Fix Re-Login race condition

### DIFF
--- a/volkswagencarnet/vw_connection.py
+++ b/volkswagencarnet/vw_connection.py
@@ -101,7 +101,6 @@ class Connection:
 
         _LOGGER.info("Successfully logged in")
         self._session_tokens["identity"] = self._session_tokens["Legacy"].copy()
-        self._session_logged_in = True
 
         # Get list of vehicles from account
         _LOGGER.debug("Fetching vehicles associated with account")
@@ -348,6 +347,7 @@ class Connection:
                 _LOGGER.warning("User identity token could not be verified!")
             else:
                 _LOGGER.debug("User identity token verified OK.")
+                self._session_logged_in = True
         except Exception as error:
             _LOGGER.error(f"Login failed for {BRAND} account, {error}")
             _LOGGER.exception(error)


### PR DESCRIPTION
@oliverrahner there is an issue with the re-login process.

During the update, you might get a 401 Unauthorized error:
```
2023-12-06 11:10:11.770 DEBUG (MainThread) [volkswagencarnet.vw_connection] Going to call vehicle updates
2023-12-06 11:10:11.771 DEBUG (MainThread) [volkswagencarnet.vw_connection] HTTP GET "https://emea.bff.cariad.digital/vehicle/v1/vehicles/- 
WVXXXX/selectivestatus?jobs=access,fuelStatus,vehicleLights,vehicleHealthInspection,measurements,charging,climatisation,automation"
2023-12-06 11:10:11.773 DEBUG (MainThread) [volkswagencarnet.vw_connection] HTTP GET "https://emea.bff.cariad.digital/vehicle/v2/vehicles"
2023-12-06 11:10:11.775 DEBUG (MainThread) [volkswagencarnet.vw_connection] HTTP GET "https://emea.bff.cariad.digital/vehicle/v1/vehicles/- 
WVXXXX/parkingposition"
2023-12-06 11:10:11.777 DEBUG (MainThread) [volkswagencarnet.vw_connection] HTTP GET "https://emea.bff.cariad.digital/vehicle/v1/trips/- 
WVXXXX/shortterm/last"
2023-12-06 11:10:11.901 WARNING (MainThread) [volkswagencarnet.vw_connection] Received "unauthorized" error while fetching data: 401, message='Unauthorized', url=URL('https://emea.bff.cariad.digital/vehicle/v1/vehicles/- 
WVXXXX/parkingposition')
2023-12-06 11:10:11.901 WARNING (MainThread) [volkswagencarnet.vw_connection] Could not fetch parkingposition, HTTP status code: 401
2023-12-06 11:10:11.917 WARNING (MainThread) [volkswagencarnet.vw_connection] Received "unauthorized" error while fetching data: 401, message='Unauthorized', url=URL('https://emea.bff.cariad.digital/vehicle/v2/vehicles')
2023-12-06 11:10:11.918 WARNING (MainThread) [volkswagencarnet.vw_connection] Could not fetch vehicle data, error: 'NoneType' object is not iterable
2023-12-06 11:10:11.922 WARNING (MainThread) [volkswagencarnet.vw_connection] Received "unauthorized" error while fetching data: 401, message='Unauthorized', url=URL('https://emea.bff.cariad.digital/vehicle/v1/trips/- 
WVXXXX/shortterm/last')
2023-12-06 11:10:11.922 WARNING (MainThread) [volkswagencarnet.vw_connection] Could not fetch last trip data, server response: {'status_code': 401}
2023-12-06 11:10:11.969 WARNING (MainThread) [volkswagencarnet.vw_connection] Received "unauthorized" error while fetching data: 401, message='Unauthorized', url=URL('https://emea.bff.cariad.digital/vehicle/v1/vehicles/- 
WVXXXX/selectivestatus?jobs=access,fuelStatus,vehicleLights,vehicleHealthInspection,measurements,charging,climatisation,automation')
```

This will set the `self._session_logged_in` to `False`. On the next update the `self._login()` will be triggered but nothing there is setting `self._session_logged_in` to `True` which causes all the updates after that to do a full login process.

re-login log after 401:
```
2023-12-06 11:15:11.769 DEBUG (MainThread) [volkswagencarnet.vw_connection] Requesting openid config
2023-12-06 11:15:11.884 DEBUG (MainThread) [volkswagencarnet.vw_connection] Get authorization page from "https://identity.vwgroup.io/oidc/v1/authorize"
2023-12-06 11:15:11.884 DEBUG (MainThread) [volkswagencarnet.vw_connection] Request headers: "{'Connection': 'keep-alive', 'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9', 'Accept-Encoding': 'gzip, deflate', 'Content-Type': 'application/x-www-form-urlencoded'}"
2023-12-06 11:15:11.995 DEBUG (MainThread) [volkswagencarnet.vw_connection] Got redirect to "https://identity.vwgroup.io/signin-service/v1/signin/a24fba63-34b3-4d43-b181-942111e6bda8@apps_vw-dilab_com?relayState=- 
xxx"
2023-12-06 11:15:12.081 DEBUG (MainThread) [volkswagencarnet.vw_connection] Got authorization endpoint
2023-12-06 11:15:12.257 DEBUG (MainThread) [volkswagencarnet.vw_connection] Authenticating with email and password.
2023-12-06 11:15:12.257 DEBUG (MainThread) [volkswagencarnet.vw_connection] Using login action url: "https://identity.vwgroup.io/signin-service/v1/a24fba63-34b3-4d43-b181-942111e6bda8@apps_vw-dilab_com/login/authenticate"
2023-12-06 11:15:12.506 DEBUG (MainThread) [volkswagencarnet.vw_connection] Parsing login response.
2023-12-06 11:15:12.506 DEBUG (MainThread) [volkswagencarnet.vw_connection] Following redirect to "https://identity.vwgroup.io/oidc/v1/oauth/sso?clientId=a24fba63-34b3-4d43-b181-942111e6bda8@apps_vw-dilab_com&relayState=- 
xxx&userId=825ac46b-d53d-4275-8954-b640fde9e489&HMAC=xxx"
2023-12-06 11:15:12.552 DEBUG (MainThread) [volkswagencarnet.vw_connection] Following redirect to "https://identity.vwgroup.io/signin-service/v1/consent/users/825ac46b-d53d-4275-8954-b640fde9e489/a24fba63-34b3-4d43-b181-942111e6bda8@apps_vw-dilab_com?scopes=openid%20profile%20badge%20cars%20dealers%20vin&relayState=- 
xxx&callback=https://identity.vwgroup.io/oidc/v1/oauth/client/callback&hmac=3d1b904229ebda97e7cb326f424f3cc81c25d17c4fc1efe1150919b92895204e"
2023-12-06 11:15:12.681 DEBUG (MainThread) [volkswagencarnet.vw_connection] Following redirect to "https://identity.vwgroup.io/oidc/v1/oauth/client/callback/success?user_id=825ac46b-d53d-4275-8954-b640fde9e489&client_id=a24fba63-34b3-4d43-b181-942111e6bda8@apps_vw-dilab_com&scopes=openid%20profile%20badge%20cars%20dealers%20vin&consentedScopes=openid%20profile%20badge%20cars%20dealers%20vin&relayState=- 
xxx&hmac=xxx"
2023-12-06 11:15:12.796 DEBUG (MainThread) [volkswagencarnet.vw_connection] Login successful, received authorization code.
2023-12-06 11:15:12.796 DEBUG (MainThread) [volkswagencarnet.vw_connection] Trying to fetch user identity tokens.
2023-12-06 11:15:13.112 DEBUG (MainThread) [volkswagencarnet.vw_connection] Got token token_type
2023-12-06 11:15:13.113 DEBUG (MainThread) [volkswagencarnet.vw_connection] Got token expires_in
2023-12-06 11:15:13.113 DEBUG (MainThread) [volkswagencarnet.vw_connection] Got token id_token
2023-12-06 11:15:13.113 DEBUG (MainThread) [volkswagencarnet.vw_connection] Got token access_token
2023-12-06 11:15:13.113 DEBUG (MainThread) [volkswagencarnet.vw_connection] Got token refresh_token
2023-12-06 11:15:13.162 DEBUG (MainThread) [volkswagencarnet.vw_connection] User identity token verified OK.
2023-12-06 11:15:13.162 DEBUG (MainThread) [volkswagencarnet.vw_connection] Going to call vehicle updates
2023-12-06 11:15:13.163 DEBUG (MainThread) [volkswagencarnet.vw_connection] HTTP GET "https://emea.bff.cariad.digital/vehicle/v1/vehicles/- 
WVXXXX/selectivestatus?jobs=access,fuelStatus,vehicleLights,vehicleHealthInspection,measurements,charging,climatisation,automation"
2023-12-06 11:15:13.166 DEBUG (MainThread) [volkswagencarnet.vw_connection] HTTP GET "https://emea.bff.cariad.digital/vehicle/v2/vehicles"
2023-12-06 11:15:13.168 DEBUG (MainThread) [volkswagencarnet.vw_connection] HTTP GET "https://emea.bff.cariad.digital/vehicle/v1/vehicles/- 
WVXXXX/parkingposition"
2023-12-06 11:15:13.169 DEBUG (MainThread) [volkswagencarnet.vw_connection] HTTP GET "https://emea.bff.cariad.digital/vehicle/v1/trips/- 
WVXXXX/shortterm/last"
```

This fix solves this issue.