### PR TITLE
Introduction of API Status sensors

### DIFF
--- a/volkswagencarnet/vw_connection.py
+++ b/volkswagencarnet/vw_connection.py
@@ -1270,10 +1270,11 @@ class Connection:
         elif "token" in url:
             self._service_status["token"] = status
         else:
-            _LOGGER.debug(f'Use-case is not covered! URL: {url}')
+            _LOGGER.debug(f'Unhandled API URL: "{url}"')
 
     async def get_service_status(self):
         """Return list of service statuses."""
+        _LOGGER.debug("Getting API status updates")
         return self._service_status
 
     # Class helpers #

--- a/volkswagencarnet/vw_connection.py
+++ b/volkswagencarnet/vw_connection.py
@@ -1235,10 +1235,8 @@ class Connection:
 
     async def update_service_status(self, url, response_code):
         """Update service status."""
-        if response_code == 200 or response_code == 204:
+        if response_code in [200, 204, 207]:
             status = "Up"
-        elif response_code == 207:
-            status = "Warning"
         elif response_code == 429:
             status = "Rate limited"
         else:

--- a/volkswagencarnet/vw_connection.py
+++ b/volkswagencarnet/vw_connection.py
@@ -81,7 +81,7 @@ class Connection:
         self._jarCookie = ""
         self._state = {}
 
-        self._service_status = {'vehicles': 'Unknown', 'capabilities': 'Unknown', 'selectivestatus': 'Unknown', 'trips': 'Unknown', 'parkingposition': 'Unknown', 'token': 'Unknown'}
+        self._service_status = {}
 
     def _clear_cookies(self):
         self._session._cookie_jar._cookies.clear()

--- a/volkswagencarnet/vw_connection.py
+++ b/volkswagencarnet/vw_connection.py
@@ -385,46 +385,55 @@ class Connection:
     async def _request(self, method, url, **kwargs):
         """Perform a query to the VW-Group API."""
         _LOGGER.debug(f'HTTP {method} "{url}"')
-        async with self._session.request(
-            method,
-            url,
-            headers=self._session_headers,
-            timeout=ClientTimeout(total=TIMEOUT.seconds),
-            cookies=self._jarCookie,
-            raise_for_status=False,
-            **kwargs,
-        ) as response:
-            response.raise_for_status()
+        try:
+            async with self._session.request(
+                method,
+                url,
+                headers=self._session_headers,
+                timeout=ClientTimeout(total=TIMEOUT.seconds),
+                cookies=self._jarCookie,
+                raise_for_status=False,
+                **kwargs,
+            ) as response:
+                response.raise_for_status()
 
-            # Update cookie jar
-            if self._jarCookie != "":
-                self._jarCookie.update(response.cookies)
-            else:
-                self._jarCookie = response.cookies
-
-            # Update service status
-            await self.update_service_status(url, response.status)
-
-            try:
-                if response.status == 204:
-                    res = {"status_code": response.status}
-                elif response.status >= 200 or response.status <= 300:
-                    res = await response.json(loads=json_loads)
+                # Update cookie jar
+                if self._jarCookie != "":
+                    self._jarCookie.update(response.cookies)
                 else:
-                    res = {}
-                    _LOGGER.debug(f"Not success status code [{response.status}] response: {response.text}")
-                if "X-RateLimit-Remaining" in response.headers:
-                    res["rate_limit_remaining"] = response.headers.get("X-RateLimit-Remaining", "")
-            except Exception:
-                res = {}
-                _LOGGER.debug(f"Something went wrong [{response.status}] response: {response.text}")
-                return res
+                    self._jarCookie = response.cookies
 
-            if self._session_fulldebug:
-                _LOGGER.debug(f'Request for "{url}" returned with status code [{response.status}], response: {res}')
-            else:
-                _LOGGER.debug(f'Request for "{url}" returned with status code [{response.status}]')
-            return res
+                # Update service status
+                await self.update_service_status(url, response.status)
+
+                try:
+                    if response.status == 204:
+                        res = {"status_code": response.status}
+                    elif response.status >= 200 or response.status <= 300:
+                        res = await response.json(loads=json_loads)
+                    else:
+                        res = {}
+                        _LOGGER.debug(f"Not success status code [{response.status}] response: {response.text}")
+                    if "X-RateLimit-Remaining" in response.headers:
+                        res["rate_limit_remaining"] = response.headers.get("X-RateLimit-Remaining", "")
+                except Exception:
+                    res = {}
+                    _LOGGER.debug(f"Something went wrong [{response.status}] response: {response.text}")
+                    return res
+
+                if self._session_fulldebug:
+                    _LOGGER.debug(f'Request for "{url}" returned with status code [{response.status}], response: {res}')
+                else:
+                    _LOGGER.debug(f'Request for "{url}" returned with status code [{response.status}]')
+                return res
+        except client_exceptions.ClientResponseError as httperror:
+            # Update service status
+            await self.update_service_status(url, httperror.code)
+            raise httperror from None
+        except Exception as error:
+            # Update service status
+            await self.update_service_status(url, 1000)
+            raise error from None
 
     async def get(self, url, vin="", tries=0):
         """Perform a get query."""
@@ -1243,6 +1252,8 @@ class Connection:
             status = "Forbidden"
         elif response_code == 429:
             status = "Rate limited"
+        elif response_code == 1000:
+            status = "Error"
         else:
             status = "Down"
 

--- a/volkswagencarnet/vw_connection.py
+++ b/volkswagencarnet/vw_connection.py
@@ -1239,6 +1239,8 @@ class Connection:
             status = "Up"
         elif response_code == 207:
             status = "Warning"
+        elif response_code == 429:
+            status = "Rate limited"
         else:
             status = "Down"
 

--- a/volkswagencarnet/vw_connection.py
+++ b/volkswagencarnet/vw_connection.py
@@ -1216,7 +1216,7 @@ class Connection:
             response = await self._session.post(
                 url="https://emea.bff.cariad.digital/login/v1/idk/token", headers=tHeaders, data=body
             )
-            self.update_service_status("token", response.status)
+            await self.update_service_status("token", response.status)
             if response.status == 200:
                 tokens = await response.json()
                 # Verify Token
@@ -1237,6 +1237,10 @@ class Connection:
         """Update service status."""
         if response_code in [200, 204, 207]:
             status = "Up"
+        elif response_code == 401:
+            status = "Unauthorized"
+        elif response_code == 403:
+            status = "Forbidden"
         elif response_code == 429:
             status = "Rate limited"
         else:

--- a/volkswagencarnet/vw_dashboard.py
+++ b/volkswagencarnet/vw_dashboard.py
@@ -994,6 +994,42 @@ def create_instruments():
             icon="mdi:chat-alert",
             unit="",
         ),
+        Sensor(
+            attr="api_vehicles_status",
+            name="API vehicles",
+            icon="mdi:api",
+            unit="",
+        ),
+        Sensor(
+            attr="api_capabilities_status",
+            name="API capabilities",
+            icon="mdi:api",
+            unit="",
+        ),
+        Sensor(
+            attr="api_trips_status",
+            name="API trips",
+            icon="mdi:api",
+            unit="",
+        ),
+        Sensor(
+            attr="api_selectivestatus_status",
+            name="API selectivestatus",
+            icon="mdi:api",
+            unit="",
+        ),
+        Sensor(
+            attr="api_parkingposition_status",
+            name="API parkingposition",
+            icon="mdi:api",
+            unit="",
+        ),
+        Sensor(
+            attr="api_token_status",
+            name="API token",
+            icon="mdi:api",
+            unit="",
+        ),
         BinarySensor(attr="external_power", name="External power", device_class=VWDeviceClass.POWER),
         BinarySensor(attr="energy_flow", name="Energy flow", device_class=VWDeviceClass.POWER),
         BinarySensor(

--- a/volkswagencarnet/vw_vehicle.py
+++ b/volkswagencarnet/vw_vehicle.py
@@ -185,6 +185,10 @@ class Vehicle:
                 #     self.get_timerprogramming(),
                 #     return_exceptions=True,
             )
+            await asyncio.sleep(10)
+            await asyncio.gather(
+                self.get_service_status()
+            )
         else:
             _LOGGER.info(f"Vehicle with VIN {self.vin} is deactivated.")
 
@@ -214,6 +218,12 @@ class Vehicle:
             data = await self._connection.getTripLast(self.vin)
             if data:
                 self._states.update(data)
+
+    async def get_service_status(self):
+        """Fetch service status."""
+        data = await self._connection.get_service_status()
+        if data:
+            self._states.update({"service_status": data})
 
     async def get_realcardata(self):
         """Fetch realcardata."""
@@ -2566,3 +2576,93 @@ class Vehicle:
     def has_combustion_engine(self):
         """Return true if car has a combustion engine."""
         return self.is_primary_drive_combustion() or self.is_secondary_drive_combustion()
+
+    @property
+    def api_vehicles_status(self) -> bool:
+        """Check vehicles API status."""
+        return find_path(self.attrs, "service_status.vehicles")
+
+    @property
+    def api_vehicles_status_last_updated(self) -> datetime:
+        """Return attribute last updated timestamp."""
+        return datetime.now()
+
+    @property
+    def is_api_vehicles_status_supported(self):
+        """Vehicles API status is always supported."""
+        return True
+
+    @property
+    def api_capabilities_status(self) -> bool:
+        """Check capabilities API status."""
+        return find_path(self.attrs, "service_status.capabilities")
+
+    @property
+    def api_capabilities_status_last_updated(self) -> datetime:
+        """Return attribute last updated timestamp."""
+        return datetime.now()
+
+    @property
+    def is_api_capabilities_status_supported(self):
+        """Capabilities API status is always supported."""
+        return True
+
+    @property
+    def api_trips_status(self) -> bool:
+        """Check trips API status."""
+        return find_path(self.attrs, "service_status.trips")
+
+    @property
+    def api_trips_status_last_updated(self) -> datetime:
+        """Return attribute last updated timestamp."""
+        return datetime.now()
+
+    @property
+    def is_api_trips_status_supported(self):
+        """Trips API status is always supported."""
+        return True
+
+    @property
+    def api_selectivestatus_status(self) -> bool:
+        """Check selectivestatus API status."""
+        return find_path(self.attrs, "service_status.selectivestatus")
+
+    @property
+    def api_selectivestatus_status_last_updated(self) -> datetime:
+        """Return attribute last updated timestamp."""
+        return datetime.now()
+
+    @property
+    def is_api_selectivestatus_status_supported(self):
+        """Selectivestatus API status is always supported."""
+        return True
+
+    @property
+    def api_parkingposition_status(self) -> bool:
+        """Check parkingposition API status."""
+        return find_path(self.attrs, "service_status.parkingposition")
+
+    @property
+    def api_parkingposition_status_last_updated(self) -> datetime:
+        """Return attribute last updated timestamp."""
+        return datetime.now()
+
+    @property
+    def is_api_parkingposition_status_supported(self):
+        """Parkingposition API status is always supported."""
+        return True
+
+    @property
+    def api_token_status(self) -> bool:
+        """Check token API status."""
+        return find_path(self.attrs, "service_status.token")
+
+    @property
+    def api_token_status_last_updated(self) -> datetime:
+        """Return attribute last updated timestamp."""
+        return datetime.now()
+
+    @property
+    def is_api_token_status_supported(self):
+        """Parkingposition API status is always supported."""
+        return True

--- a/volkswagencarnet/vw_vehicle.py
+++ b/volkswagencarnet/vw_vehicle.py
@@ -185,7 +185,6 @@ class Vehicle:
                 #     self.get_timerprogramming(),
                 #     return_exceptions=True,
             )
-            await asyncio.sleep(10)
             await asyncio.gather(
                 self.get_service_status()
             )

--- a/volkswagencarnet/vw_vehicle.py
+++ b/volkswagencarnet/vw_vehicle.py
@@ -2580,7 +2580,7 @@ class Vehicle:
     @property
     def api_vehicles_status(self) -> bool:
         """Check vehicles API status."""
-        return find_path(self.attrs, "service_status.vehicles")
+        return self.attrs.get("service_status", {}).get("vehicles", "Unknown")
 
     @property
     def api_vehicles_status_last_updated(self) -> datetime:
@@ -2595,7 +2595,7 @@ class Vehicle:
     @property
     def api_capabilities_status(self) -> bool:
         """Check capabilities API status."""
-        return find_path(self.attrs, "service_status.capabilities")
+        return self.attrs.get("service_status", {}).get("capabilities", "Unknown")
 
     @property
     def api_capabilities_status_last_updated(self) -> datetime:
@@ -2610,7 +2610,7 @@ class Vehicle:
     @property
     def api_trips_status(self) -> bool:
         """Check trips API status."""
-        return find_path(self.attrs, "service_status.trips")
+        return self.attrs.get("service_status", {}).get("trips", "Unknown")
 
     @property
     def api_trips_status_last_updated(self) -> datetime:
@@ -2625,7 +2625,7 @@ class Vehicle:
     @property
     def api_selectivestatus_status(self) -> bool:
         """Check selectivestatus API status."""
-        return find_path(self.attrs, "service_status.selectivestatus")
+        return self.attrs.get("service_status", {}).get("selectivestatus", "Unknown")
 
     @property
     def api_selectivestatus_status_last_updated(self) -> datetime:
@@ -2640,7 +2640,7 @@ class Vehicle:
     @property
     def api_parkingposition_status(self) -> bool:
         """Check parkingposition API status."""
-        return find_path(self.attrs, "service_status.parkingposition")
+        return self.attrs.get("service_status", {}).get("parkingposition", "Unknown")
 
     @property
     def api_parkingposition_status_last_updated(self) -> datetime:
@@ -2655,7 +2655,7 @@ class Vehicle:
     @property
     def api_token_status(self) -> bool:
         """Check token API status."""
-        return find_path(self.attrs, "service_status.token")
+        return self.attrs.get("service_status", {}).get("token", "Unknown")
 
     @property
     def api_token_status_last_updated(self) -> datetime:


### PR DESCRIPTION
Introduction of API Status sensors

The default status for the supported APIs is "Unknown".

The following logic applies to provide a status:
```
        if response_code in [200, 204, 207]:
            status = "Up"
        elif response_code == 401:
            status = "Unauthorized"
        elif response_code == 403:
            status = "Forbidden"
        elif response_code == 429:
            status = "Rate limited"
        elif response_code == 1000:
            status = "Error"
        else:
            status = "Down"
```

![Screenshot 2023-12-08 at 19 52 04](https://github.com/robinostlund/volkswagencarnet/assets/630000/d1a0034e-7c93-422f-9951-2e14f41daea8)

FYI @oliverrahner 