### PR TITLE
Fix refresh_tokens flow

### DIFF
--- a/volkswagencarnet/vw_connection.py
+++ b/volkswagencarnet/vw_connection.py
@@ -1218,6 +1218,7 @@ class Connection:
                     _LOGGER.warning("Token could not be verified!")
                 for token in tokens:
                     self._session_tokens["identity"][token] = tokens[token]
+                self._session_headers["Authorization"] = "Bearer " + self._session_tokens["identity"]["access_token"]
             else:
                 _LOGGER.warning(f"Something went wrong when refreshing {BRAND} account tokens.")
                 return False


### PR DESCRIPTION
A new token is not being set for the Authorization header after the token refresh.

It fixes the issue with the refresh_tokens flow that I've described in this discussion: https://github.com/robinostlund/volkswagencarnet/discussions/224

FYI @oliverrahner 