### PR TITLE
Fix combined range sensor logic

### DIFF
--- a/volkswagencarnet/vw_vehicle.py
+++ b/volkswagencarnet/vw_vehicle.py
@@ -1194,8 +1194,9 @@ class Vehicle:
 
         :return:
         """
-        return is_valid_path(self.attrs, "measurements.rangeStatus.value.totalRange_km")
-
+        if is_valid_path(self.attrs, "measurements.rangeStatus.value.totalRange_km"):
+            return self.is_electric_range_supported and self.is_combustion_range_supported
+        return False
     @property
     def fuel_level(self) -> int:
         """


### PR DESCRIPTION
A combined range sensor sensor is not applicable for combustion vehicles.