### PR TITLE
Add state_class to fuel, gas and adblue

### DIFF
--- a/volkswagencarnet/vw_dashboard.py
+++ b/volkswagencarnet/vw_dashboard.py
@@ -1456,18 +1456,21 @@ def create_instruments():
             name="Adblue level",
             icon="mdi:fuel",
             unit="km",
+            state_class=VWStateClass.MEASUREMENT,
         ),
         Sensor(
             attr="fuel_level",
             name="Fuel level",
             icon="mdi:fuel",
             unit="%",
+            state_class=VWStateClass.MEASUREMENT,
         ),
         Sensor(
             attr="gas_level",
             name="Gas level",
             icon="mdi:gas-cylinder",
             unit="%",
+            state_class=VWStateClass.MEASUREMENT,
         ),
         Sensor(
             attr="service_inspection",


### PR DESCRIPTION
Add the missing `state_class: measurement` to the fuel, gas and adblue entities so they can be tracked in the long term statistics (_History_ page).