### PR TITLE
Add read-only support for active ventilation status

### DIFF
--- a/tests/credentials.py.sample
+++ b/tests/credentials.py.sample
@@ -2,5 +2,5 @@
 # Oh, and replace the data in credentials.py with your own
 spin = '1234'
 username = 'john.doe@localhost.localnet'
-pasword = 'passw0rd'
+password = 'passw0rd'
 vin = 'WVWZZXXXXX1234567'

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -11,7 +11,7 @@ import pytest
 from volkswagencarnet import vw_connection
 
 try:
-    from credentials import password, spin, username, vin
+    from tests.credentials import password, spin, username, vin
 except ImportError:
     username = password = spin = vin = None
 

--- a/volkswagencarnet/vw_const.py
+++ b/volkswagencarnet/vw_const.py
@@ -282,6 +282,17 @@ class Paths:
     )
     CLIMATISATION_REM_TIME = f"{Services.CLIMATISATION}.climatisationStatus.value.remainingClimatisationTime_min"
 
+    # Active ventilation (combustion cars without auxiliary heating)
+    ACTIVE_VENTILATION_STATE = (
+        f"{Services.CLIMATISATION}.activeVentilationStatus.value.climatisationState"
+    )
+    ACTIVE_VENTILATION_TS = (
+        f"{Services.CLIMATISATION}.activeVentilationStatus.value.carCapturedTimestamp"
+    )
+    ACTIVE_VENTILATION_REM_TIME = (
+        f"{Services.CLIMATISATION}.activeVentilationStatus.value.remainingClimatisationTime_min"
+    )
+
     # Climatisation Settings
     CLIMATISATION_SETTINGS_TS = (
         f"{Services.CLIMATISATION}.climatisationSettings.value.carCapturedTimestamp"

--- a/volkswagencarnet/vw_dashboard.py
+++ b/volkswagencarnet/vw_dashboard.py
@@ -2175,6 +2175,26 @@ _INSTRUMENT_DEFS = [
         Sensor,
         [],
         {
+            "attr": "active_ventilation",
+            "name": "Active ventilation",
+            "icon": "mdi:fan",
+        },
+    ),
+    (
+        Sensor,
+        [],
+        {
+            "attr": "active_ventilation_remaining_time",
+            "name": "Active ventilation remaining time",
+            "icon": "mdi:fan-clock",
+            "unit": "min",
+            "device_class": VWDeviceClass.DURATION,
+        },
+    ),
+    (
+        Sensor,
+        [],
+        {
             "attr": "climatisation_target_temperature",
             "name": "Climatisation target temperature",
             "icon": "mdi:thermometer",

--- a/volkswagencarnet/vw_vehicle.py
+++ b/volkswagencarnet/vw_vehicle.py
@@ -1877,6 +1877,42 @@ class Vehicle:
         """Return true if electric climatisation remaining climatisation time is supported."""
         return is_valid_path(self.attrs, Paths.CLIMATISATION_REM_TIME)
 
+    # Active ventilation (read-only)
+    @property
+    def active_ventilation(self) -> bool:
+        """Return status of active ventilation."""
+        state = find_path(self.attrs, Paths.ACTIVE_VENTILATION_STATE)
+
+        if state is None:
+            return False
+        return state not in ["off", "invalid"]
+
+    @property
+    def active_ventilation_remaining_time(self) -> int:
+        """Return remaining time for active ventilation."""
+        return find_path(self.attrs, Paths.ACTIVE_VENTILATION_REM_TIME)
+    
+    @property
+    def active_ventilation_remaining_time_last_updated(self) -> datetime:
+        """Return timestamp of last active ventilation remaining time update."""
+        return find_path(self.attrs, Paths.ACTIVE_VENTILATION_TS)
+
+    @property
+    def is_active_ventilation_remaining_time_supported(self) -> bool:
+        """Return true if active ventilation remaining time is supported."""
+        return is_valid_path(self.attrs, Paths.ACTIVE_VENTILATION_REM_TIME)
+
+
+    @property
+    def active_ventilation_last_updated(self) -> datetime:
+        """Return timestamp of last active ventilation update."""
+        return find_path(self.attrs, Paths.ACTIVE_VENTILATION_TS)
+
+    @property
+    def is_active_ventilation_supported(self) -> bool:
+        """Return true if active ventilation is available in the vehicle."""
+        return is_valid_path(self.attrs, Paths.ACTIVE_VENTILATION_STATE)
+    
     @property
     def auxiliary_climatisation(self) -> bool:
         """Return status of auxiliary climatisation."""


### PR DESCRIPTION
Summary

This PR adds read-only support for the “active ventilation” feature exposed by the VW API on some combustion vehicles that have ventilation but no auxiliary heating.

Affected vehicles (e.g. Golf 8 GTI) report activeVentilationStatus and related fields in the API response, but the library currently does not expose them. This prevents integrations like Home Assistant from showing the ventilation state.

Related Home Assistant issue: robinostlund/homeassistant-volkswagencarnet#834

Changes

1. Added new paths in vw_const.py
Support for the following API fields:

activeVentilationStatus.climatisationState

activeVentilationStatus.remainingClimatisationTime_min

corresponding timestamp

2. Added read-only properties in vw_vehicle.py

active_ventilation

active_ventilation_remaining_time

timestamps for both

supported-checks via is_valid_path

These follow the existing climatisation pattern and are strictly read-only (no control endpoints added).

3. Added two instruments in vw_dashboard.py

active_ventilation (boolean sensor)

active_ventilation_remaining_time (minutes)

This allows external integrations to expose the information as proper entities.

4. Minor cleanup

Corrected pasword → password in credentials.py.sample

Adjusted import so credentials.py works when placed inside tests/

All unit tests pass.

Happy to adjust naming or entity type if preferred.