### PR TITLE
Add subscription expiration date sensor

### DIFF
--- a/volkswagencarnet/vw_dashboard.py
+++ b/volkswagencarnet/vw_dashboard.py
@@ -2481,6 +2481,18 @@ _INSTRUMENT_DEFS = [
         Sensor,
         [],
         {
+            "attr": "api_subscription_expiration",
+            "name": "API subscription expiration",
+            "icon": "mdi:calendar-alert",
+            "unit": "",
+            "device_class": VWDeviceClass.TIMESTAMP,
+            "entity_type": "diag",
+        },
+    ),
+    (
+        Sensor,
+        [],
+        {
             "attr": "last_data_refresh",
             "name": "Last data refresh",
             "icon": "mdi:clock",

--- a/volkswagencarnet/vw_vehicle.py
+++ b/volkswagencarnet/vw_vehicle.py
@@ -3737,6 +3737,31 @@ class Vehicle:
         return True
 
     @property
+    def api_subscription_expiration(self) -> datetime:
+        """Check nearest API subscription expiration date."""
+        # Extract the service expiration values if they exist and are not None
+        expirations = [
+            value["expiration"]
+            for value in self._services.values()
+            if isinstance(value, dict)
+            and "expiration" in value
+            and value["expiration"] is not None
+        ]
+
+        # Return the minimum date, or None if the list is empty
+        return min(expirations) if expirations else None
+
+    @property
+    def api_subscription_expiration_last_updated(self) -> datetime:
+        """Return attribute last updated timestamp."""
+        return datetime.now(UTC)
+
+    @property
+    def is_api_subscription_expiration_supported(self):
+        """API subscription expiration is always supported."""
+        return True
+
+    @property
     def last_data_refresh(self) -> datetime:
         """Check when services were refreshed successfully for the last time."""
         last_data_refresh_path = "refreshTimestamp"


### PR DESCRIPTION
Extract the nearest expiration date of the services as a new sensor.

When merged, this will close the feature request https://github.com/robinostlund/homeassistant-volkswagencarnet/issues/890.