### PR TITLE
Correct statistic history for xxx_trip_total entities

### DIFF
--- a/volkswagencarnet/vw_dashboard.py
+++ b/volkswagencarnet/vw_dashboard.py
@@ -2188,7 +2188,7 @@ _INSTRUMENT_DEFS = [
             "icon": "mdi:car-battery",
             "unit": "kWh",
             "device_class": VWDeviceClass.ENERGY,
-            "state_class": VWStateClass.TOTAL,
+            "state_class": VWStateClass.TOTAL_INCREASING,
         },
     ),
     (
@@ -2200,7 +2200,7 @@ _INSTRUMENT_DEFS = [
             "icon": "mdi:fuel",
             "unit": "L",
             "device_class": VWDeviceClass.VOLUME,
-            "state_class": VWStateClass.TOTAL,
+            "state_class": VWStateClass.TOTAL_INCREASING,
         },
     ),
     (
@@ -2318,7 +2318,7 @@ _INSTRUMENT_DEFS = [
             "icon": "mdi:car-battery",
             "unit": "kWh",
             "device_class": VWDeviceClass.ENERGY,
-            "state_class": VWStateClass.TOTAL,
+            "state_class": VWStateClass.TOTAL_INCREASING,
         },
     ),
     (
@@ -2330,7 +2330,7 @@ _INSTRUMENT_DEFS = [
             "icon": "mdi:fuel",
             "unit": "L",
             "device_class": VWDeviceClass.VOLUME,
-            "state_class": VWStateClass.TOTAL,
+            "state_class": VWStateClass.TOTAL_INCREASING,
         },
     ),
     # Sensors - auxiliary / timers / misc

--- a/volkswagencarnet/vw_vehicle.py
+++ b/volkswagencarnet/vw_vehicle.py
@@ -3031,6 +3031,14 @@ class Vehicle:
         return self._is_trip_supported(Services.TRIP_LAST, "mileage_km")
 
     @property
+    def last_trip_start_km(self):
+        return self._get_trip_value(Services.TRIP_LAST, "startMileage_km")
+
+    @property
+    def is_last_trip_start_km_supported(self):
+        return self._is_trip_supported(Services.TRIP_LAST, "startMileage_km")
+
+    @property
     def last_trip_average_recuperation(self):
         return self._get_trip_value(Services.TRIP_LAST, "averageRecuperation")
 


### PR DESCRIPTION
As explained thoroughly [HERE](https://github.com/robinostlund/volkswagencarnet/issues/311#issuecomment-4016981077), **last trip** energy and fuel consuption should set their `last_reset` date to properly count the energy consumed in the statistics (and this is actually done in **another linked PR** of the Home Assistant integration). A logic has to be added in the integration to detect a new trip and set the `last_reset` date accordingly.

**Refuel** and **long term** electric/fuel consumption, instead, should be set to `SensorStateClass.TOTAL_INCREASING` (as they still reset after some time, meaning every refuel or 99h) for the same reason.

Closes #311.