### PR TITLE
Expose charge mode configuration and current charging status charge mode

### DIFF
--- a/tests/vw_vehicle_test.py
+++ b/tests/vw_vehicle_test.py
@@ -244,3 +244,35 @@ class VehiclePropertyTest(IsolatedAsyncioTestCase):
             }
         }
         assert not vehicle.has_combustion_engine
+
+    async def test_charge_mode_exposed(self):
+        """Test that charge mode data is exposed from selectivestatus."""
+        vehicle = Vehicle(conn=None, url="dummy34")
+        vehicle._states[Services.CHARGING] = {
+            "chargingStatus": {
+                "value": {"chargeMode": "timer"}
+            },
+            "chargeMode": {
+                "value": {
+                    "preferredChargeMode": "preferredChargingTimes",
+                    "availableChargeModes": [
+                        "manual",
+                        "timer",
+                        "preferredChargingTimes",
+                        "timerChargingWithClimatisation",
+                    ],
+                }
+            },
+        }
+
+        assert vehicle.charging_status_charge_mode == "timer"
+        assert vehicle.is_charging_status_charge_mode_supported
+        assert vehicle.charge_mode == vehicle._states[Services.CHARGING]["chargeMode"]["value"]
+        assert vehicle.preferred_charge_mode == "preferredChargingTimes"
+        assert vehicle.available_charge_modes == [
+            "manual",
+            "timer",
+            "preferredChargingTimes",
+            "timerChargingWithClimatisation",
+        ]
+        assert vehicle.is_charge_mode_supported

--- a/tests/vw_vehicle_test.py
+++ b/tests/vw_vehicle_test.py
@@ -249,9 +249,7 @@ class VehiclePropertyTest(IsolatedAsyncioTestCase):
         """Test that charge mode data is exposed from selectivestatus."""
         vehicle = Vehicle(conn=None, url="dummy34")
         vehicle._states[Services.CHARGING] = {
-            "chargingStatus": {
-                "value": {"chargeMode": "timer"}
-            },
+            "chargingStatus": {"value": {"chargeMode": "timer"}},
             "chargeMode": {
                 "value": {
                     "preferredChargeMode": "preferredChargingTimes",
@@ -267,7 +265,10 @@ class VehiclePropertyTest(IsolatedAsyncioTestCase):
 
         assert vehicle.charging_status_charge_mode == "timer"
         assert vehicle.is_charging_status_charge_mode_supported
-        assert vehicle.charge_mode == vehicle._states[Services.CHARGING]["chargeMode"]["value"]
+        assert (
+            vehicle.charge_mode
+            == vehicle._states[Services.CHARGING]["chargeMode"]["value"]
+        )
         assert vehicle.preferred_charge_mode == "preferredChargingTimes"
         assert vehicle.available_charge_modes == [
             "manual",

--- a/volkswagencarnet/vw_const.py
+++ b/volkswagencarnet/vw_const.py
@@ -169,6 +169,7 @@ class Paths:
     CHARGING_POWER = f"{Services.CHARGING}.chargingStatus.value.chargePower_kW"
     CHARGING_RATE = f"{Services.CHARGING}.chargingStatus.value.chargeRate_kmph"
     CHARGING_TYPE = f"{Services.CHARGING}.chargingStatus.value.chargeType"
+    CHARGING_STATUS_CHARGE_MODE = f"{Services.CHARGING}.chargingStatus.value.chargeMode"
     CHARGING_TIME_LEFT = (
         f"{Services.CHARGING}.chargingStatus.value.remainingChargingTimeToComplete_min"
     )
@@ -199,6 +200,10 @@ class Paths:
     CHARGING_SET_AUTO_UNLOCK_PLUG = (
         f"{Services.CHARGING}.chargingSettings.value.autoUnlockPlugWhenChargedAC"
     )
+
+    CHARGE_MODE = f"{Services.CHARGING}.chargeMode.value"
+    CHARGE_MODE_PREFERRED = f"{Services.CHARGING}.chargeMode.value.preferredChargeMode"
+    CHARGE_MODE_AVAILABLE = f"{Services.CHARGING}.chargeMode.value.availableChargeModes"
 
     # Measurements - Odometer
     MEASUREMENTS_ODO = f"{Services.MEASUREMENTS}.odometerStatus.value.odometer"

--- a/volkswagencarnet/vw_vehicle.py
+++ b/volkswagencarnet/vw_vehicle.py
@@ -1294,6 +1294,16 @@ class Vehicle:
         return is_valid_path(self.attrs, Paths.CHARGING_RATE)
 
     @property
+    def charging_status_charge_mode(self) -> str | None:
+        """Return current charge mode from charging status."""
+        return find_path(self.attrs, Paths.CHARGING_STATUS_CHARGE_MODE)
+
+    @property
+    def is_charging_status_charge_mode_supported(self) -> bool:
+        """Return true if charging status charge mode is supported."""
+        return is_valid_path(self.attrs, Paths.CHARGING_STATUS_CHARGE_MODE)
+
+    @property
     def charger_type(self) -> str:
         ct = find_path(self.attrs, Paths.CHARGING_TYPE)
         return "AC" if ct == "ac" else "DC" if ct == "dc" else "Unknown"
@@ -1400,6 +1410,26 @@ class Vehicle:
     def is_charge_max_ac_ampere_supported(self) -> bool:
         """Return true if Charger Max Ampere is supported."""
         return is_valid_path(self.attrs, Paths.CHARGING_SET_MAX_CHARGE_AC_A)
+
+    @property
+    def charge_mode(self) -> dict[str, object] | None:
+        """Return charge mode configuration from selectivestatus."""
+        return find_path(self.attrs, Paths.CHARGE_MODE)
+
+    @property
+    def preferred_charge_mode(self) -> str | None:
+        """Return preferred charge mode from selectivestatus."""
+        return find_path(self.attrs, Paths.CHARGE_MODE_PREFERRED)
+
+    @property
+    def available_charge_modes(self) -> list[str] | None:
+        """Return available charge modes from selectivestatus."""
+        return find_path(self.attrs, Paths.CHARGE_MODE_AVAILABLE)
+
+    @property
+    def is_charge_mode_supported(self) -> bool:
+        """Return true if charge mode information is supported."""
+        return is_valid_path(self.attrs, Paths.CHARGE_MODE)
 
     @property
     def charging_cable_locked(self) -> bool:


### PR DESCRIPTION
This adds charge mode information for EV's, like Volkswagen ID.4
Also referred in this issue: https://github.com/robinostlund/homeassistant-volkswagencarnet/issues/891
