### PR TITLE
Migrate auth endpoints to CARIAD BFF and fix login headers

### DIFF
--- a/volkswagencarnet/vw_connection.py
+++ b/volkswagencarnet/vw_connection.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime, timedelta
 import hashlib
 import logging
 from random import randint, random
+import uuid
 from urllib.parse import parse_qs, urljoin, urlparse
 from typing import Dict, Optional
 
@@ -129,7 +130,7 @@ class Connection:
         """Get OpenID config."""
         _LOGGER.debug("Requesting openid config")
         req = await self._session.get(
-            url=f"{BASE_API}/login/v1/idk/openid-configuration"
+            url=f"{BASE_API}/auth/v1/idk/oidc/openid-configuration"
         )
         if req.status != 200:
             _LOGGER.error("Failed to get OpenID configuration, status: %s", req.status)
@@ -157,6 +158,7 @@ class Connection:
                     "response_type": CLIENT_TOKEN_TYPES,
                     "client_id": CLIENT_ID,
                     "scope": CLIENT_SCOPE,
+                    "nonce": uuid.uuid4().hex,
                 },
             )
 
@@ -458,7 +460,7 @@ class Connection:
             if self._session_headers.get("identity", {}).get("refresh_token"):
                 _LOGGER.info("Revoking Identity Refresh Token")
                 params = {"token": self._session_tokens["identity"]["refresh_token"]}
-                await self.post(f"{BASE_API}/login/v1/idk/revoke", data=params)
+                await self.post(f"{BASE_API}/auth/v1/idk/oidc/revoke", data=params)
 
     # HTTP methods to API
     async def _request(self, method, url, return_raw=False, **kwargs):
@@ -1135,7 +1137,7 @@ class Connection:
                 "client_id": CLIENT_ID,
             }
             response = await self._session.post(
-                url=f"{BASE_API}/login/v1/idk/token",
+                url=f"{BASE_API}/auth/v1/idk/oidc/token",
                 headers=tHeaders,
                 data=body,
             )

--- a/volkswagencarnet/vw_const.py
+++ b/volkswagencarnet/vw_const.py
@@ -9,7 +9,7 @@ CLIENT_ID = "a24fba63-34b3-4d43-b181-942111e6bda8@apps_vw-dilab_com"
 CLIENT_SCOPE = "openid profile badge cars dealers vin"
 CLIENT_TOKEN_TYPES = "code"
 
-USER_AGENT = "Volkswagen/3.51.1-android/14"
+USER_AGENT = "Volkswagen/3.61.0-android/14"
 APP_URI = "weconnect://authenticated"
 ANDROID_PACKAGE_NAME = "com.volkswagen.weconnect"
 
@@ -20,7 +20,6 @@ HEADERS_SESSION = {
     "Accept-charset": "UTF-8",
     "Accept": "application/json",
     "User-Agent": USER_AGENT,
-    "tokentype": "IDK_TECHNICAL",
     "x-android-package-name": ANDROID_PACKAGE_NAME,
 }
 
@@ -30,6 +29,7 @@ HEADERS_AUTH = {
     "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
     "Accept-Encoding": "gzip, deflate",
     "Content-Type": "application/x-www-form-urlencoded",
+    "User-Agent": USER_AGENT,
     "x-android-package-name": ANDROID_PACKAGE_NAME,
 }
 


### PR DESCRIPTION
- Update OpenID config, token, and revoke endpoints from /login/v1/idk/ to /auth/v1/idk/oidc/ (CARIAD BFF, matching VW app 3.61.0 behavior)
- Add nonce parameter to authorization request (required by updated flow)
- Update User-Agent from 3.51.1 to 3.61.0 (current app version)
- Add User-Agent to HEADERS_AUTH (was missing, caused 401 on login)
- Remove tokentype: IDK_TECHNICAL header (no longer sent by the app)