### PR TITLE
fix(auth): switch to OIDC hybrid flow after CARIAD BFF token exchange brake

### DIFF
--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -34,6 +34,32 @@ async def test_successful_login() -> None:
     reason="Username or password is not set. Check credentials.py.sample",
 )
 @pytest.mark.asyncio
+async def test_refresh_token() -> None:
+    """Test that token refresh works after login."""
+    async with ClientSession() as session:
+        connection = vw_connection.Connection(session, username, password)
+        await connection.doLogin()
+        assert connection.logged_in is True
+
+        has_refresh_token = bool(
+            connection._session_tokens.get("identity", {}).get("refresh_token")
+        )
+        logging.getLogger().info("refresh_token present after login: %s", has_refresh_token)
+
+        if not has_refresh_token:
+            pytest.skip("No refresh_token available from hybrid flow — cannot test refresh")
+
+        result = await connection.refresh_tokens()
+        assert result is True, "refresh_tokens() returned False"
+        assert connection._session_tokens["identity"].get("access_token"), "access_token missing after refresh"
+        logging.getLogger().info("Token refresh succeeded")
+
+
+@pytest.mark.skipif(
+    username is None or password is None,
+    reason="Username or password is not set. Check credentials.py.sample",
+)
+@pytest.mark.asyncio
 @pytest.mark.skip("Not yet implemented")
 async def test_spin_action() -> None:
     """Test something that uses s-pin.

--- a/volkswagencarnet/vw_connection.py
+++ b/volkswagencarnet/vw_connection.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime, timedelta
-import hashlib
 import logging
 from random import randint, random
+import uuid
 from urllib.parse import parse_qs, urljoin, urlparse
 from typing import Dict, Optional
 
@@ -23,7 +23,6 @@ from .vw_const import (
     BRAND,
     CLIENT_ID,
     CLIENT_SCOPE,
-    CLIENT_TOKEN_TYPES,
     COUNTRY,
     HEADERS_AUTH,
     HEADERS_SESSION,
@@ -125,7 +124,7 @@ class Connection:
             await self.update()
             return True
 
-    async def get_openid_config(self) -> Dict[str, str]:
+    async def get_openid_config(self) -> dict[str, str]:
         """Get OpenID config."""
         _LOGGER.debug("Requesting openid config")
         req = await self._session.get(
@@ -136,62 +135,61 @@ class Connection:
             raise AuthenticationError(
                 f"OpenID configuration error: status {req.status}"
             )
-        return await req.json()
+        config = await req.json()
+        _LOGGER.debug("OpenID config: %s", config)
+        return config
 
     async def get_authorization_page(self, authorization_endpoint: str) -> str:
-        """Get authorization page (login page)."""
-        # https://identity.vwgroup.io/oidc/v1/authorize?nonce={NONCE}&state={STATE}&response_type={TOKEN_TYPES}&scope={SCOPE}&redirect_uri={APP_URI}&client_id={CLIENT_ID}
-        # https://identity.vwgroup.io/oidc/v1/authorize?client_id={CLIENT_ID}&scope={SCOPE}&response_type={TOKEN_TYPES}&redirect_uri={APP_URI}
+        """Fetch the Auth0 Universal Login page for credential submission.
+
+        Hits the OIDC authorization endpoint with response_type=code id_token token
+        (hybrid flow). Auth0 redirects to the login form; we follow that single
+        redirect and return the HTML so the caller can extract the state token.
+        """
         _LOGGER.debug('Requesting authorization page from "%s"', authorization_endpoint)
         self._session_auth_headers.pop("Referer", None)
         self._session_auth_headers.pop("Origin", None)
-        _LOGGER.debug('Request headers: "%s"', self._session_auth_headers)
 
-        try:
-            req = await self._session.get(
-                url=authorization_endpoint,
-                headers=self._session_auth_headers,
-                allow_redirects=False,
-                params={
-                    "redirect_uri": APP_URI,
-                    "response_type": CLIENT_TOKEN_TYPES,
-                    "client_id": CLIENT_ID,
-                    "scope": CLIENT_SCOPE,
-                },
+        params = {
+            "redirect_uri": APP_URI,
+            # Hybrid flow: Auth0 returns code + id_token + access_token in the
+            # callback so no separate token exchange with the CARIAD BFF is needed.
+            "response_type": "code id_token token",
+            "client_id": CLIENT_ID,
+            "scope": CLIENT_SCOPE,
+            "nonce": uuid.uuid4().hex,
+        }
+
+        req = await self._session.get(
+            url=authorization_endpoint,
+            headers=self._session_auth_headers,
+            allow_redirects=False,
+            params=params,
+        )
+
+        location = req.headers.get("Location")
+        if not location:
+            raise AuthenticationError(
+                f"Missing 'Location' header in authorization response. "
+                f"Status: {req.status}"
             )
 
-            # Check if the response contains a redirect location
-            location = req.headers.get("Location")
-            if not location:
-                raise AuthenticationError(
-                    f"Missing 'Location' header in authorization response. Payload returned: {await req.content.read()}"
-                )
+        ref = urljoin(authorization_endpoint, location)
+        if "error" in ref:
+            parsed_query = parse_qs(urlparse(ref).query)
+            error_msg = parsed_query.get("error", ["Unknown error"])[0]
+            error_description = parsed_query.get("error_description", ["No description"])[0]
+            _LOGGER.info("Authorization error: %s", error_description)
+            raise AuthenticationError(f"{error_msg}: {error_description}")
 
-            ref = urljoin(authorization_endpoint, location)
-            if "error" in ref:
-                parsed_query = parse_qs(urlparse(ref).query)
-                error_msg = parsed_query.get("error", ["Unknown error"])[0]
-                error_description = parsed_query.get(
-                    "error_description", ["No description"]
-                )[0]
-                _LOGGER.info("Authorization error: %s", error_description)
-                raise AuthenticationError(f"{error_msg}: {error_description}")
+        # Follow the redirect to the actual login page
+        req = await self._session.get(url=ref, headers=self._session_auth_headers, allow_redirects=False)
+        if req.status != 200:
+            raise AuthenticationError(f"Failed to fetch login page (HTTP {req.status})")
 
-            # If redirected, fetch the new location
-            req = await self._session.get(
-                url=ref, headers=self._session_auth_headers, allow_redirects=False
-            )
+        return await req.text()
 
-            if req.status != 200:
-                raise AuthenticationError("Failed to fetch authorization endpoint")
-
-            return await req.text()
-
-        except Exception as e:
-            _LOGGER.warning("Error during fetching authorization page: %s", str(e))
-            raise
-
-    def extract_state_token(self, page_content: str) -> Optional[str]:
+    def extract_state_token(self, page_content: str) -> str | None:
         """Extract state token from a page."""
         soup = BeautifulSoup(page_content, "html.parser")
         state_input = soup.select_one('input[name="state"]')
@@ -242,10 +240,6 @@ class Connection:
         # Normal success path
         return await req.text()
 
-    async def handle_login_with_password(self, session, url, auth_headers, form_data):
-        """Handle login with email and password."""
-        return await self.post_form(session, url, auth_headers, form_data, False)
-
     async def follow_redirects(
         self, session, pw_url: str, redirect_location: str
     ) -> str:
@@ -286,29 +280,22 @@ class Connection:
             max_depth -= 1
         return ref
 
-    async def _get_authorization_code(self, openid_config: dict) -> str:
-        """Get authorization code from login flow.
+    async def _get_authorization_code(self, openid_config: dict) -> tuple:
+        """Run the OIDC hybrid login flow and return the callback tokens.
 
-        Args:
-            openid_config: OpenID configuration dictionary containing
-                        authorization_endpoint and issuer
+        Uses response_type=code id_token token so identity.vwgroup.io (Auth0)
+        delivers access_token and id_token directly in the callback — these are
+        usable with the CARIAD BFF without a separate token exchange step.
 
         Returns:
-            Authorization code string
-
-        Raises:
-            AuthenticationError: If authorization fails
+            Tuple of (auth_code_jwt, id_token, access_token)
         """
-        # Get OpenID configuration
         authorization_endpoint = openid_config["authorization_endpoint"]
         auth_issuer = openid_config["issuer"]
 
-        # Get authorization page
         authorization_page = await self.get_authorization_page(authorization_endpoint)
 
-        # Extract form data
         state_token = self.extract_state_token(authorization_page)
-
         if not state_token:
             _LOGGER.error(
                 "Unable to find valid login page. "
@@ -316,11 +303,11 @@ class Connection:
             )
             raise AuthenticationError("Invalid login page - missing state token")
 
-        # Do login
         login_form = {
             "username": self._session_auth_username,
             "password": self._session_auth_password,
             "state": state_token,
+            "action": "default",
         }
         login_url = f"{auth_issuer}/u/login?state={state_token}"
 
@@ -332,42 +319,45 @@ class Connection:
             False,
         )
 
-        # Handle redirects and extract tokens
-        redirect_response = await self.follow_redirects(
+        callback_url = await self.follow_redirects(
             self._session, auth_issuer, redirect_location
         )
 
-        jwt_auth_code = parse_qs(urlparse(redirect_response).query)["code"][0]
-        return jwt_auth_code
+        parsed = urlparse(callback_url)
+        all_params = {**parse_qs(parsed.query), **parse_qs(parsed.fragment)}
+        _LOGGER.debug("Callback params keys: %s", list(all_params.keys()))
 
-    async def _exchange_code_for_tokens(
-        self, auth_code: str, token_endpoint: str
-    ) -> dict:
-        """Exchange authorization code for access tokens.
+        auth_code = all_params.get("code", [None])[0]
+        id_token = all_params.get("id_token", [None])[0]
+        access_token = all_params.get("access_token", [None])[0]
 
-        Args:
-            auth_code: Authorization code from login flow
-            token_endpoint: Token endpoint URL
+        if not auth_code:
+            raise AuthenticationError("No authorization code in callback URL")
 
-        Returns:
-            Dictionary containing tokens
+        return auth_code, id_token, access_token
 
-        Raises:
-            AuthenticationError: If token exchange fails
+    def _build_session_tokens(self, auth_code: str, id_token: str, access_token: str) -> dict:
+        """Build the session token dict from the hybrid OIDC callback values.
+
+        The hybrid flow (response_type=code id_token token) already delivers
+        access_token and id_token directly from identity.vwgroup.io. These
+        Auth0-issued tokens are valid for the CARIAD BFF, which validates them
+        against Auth0's public keys. No separate token exchange is required.
+
+        Note: the authorization code (auth_code) is not used for a server-side
+        exchange — it is decoded here only for debug logging.
         """
-        token_body = {
-            "client_id": CLIENT_ID,
-            "grant_type": "authorization_code",
-            "code": auth_code,
-            "redirect_uri": APP_URI,
+        try:
+            payload = jwt.decode(auth_code, options={"verify_signature": False})
+            _LOGGER.debug("Auth code JWT payload: %s", payload)
+        except Exception:
+            _LOGGER.debug("Auth code is not a JWT, continuing without decode")
+
+        return {
+            "access_token": access_token,
+            "id_token": id_token,
+            "token_type": "Bearer",
         }
-
-        # Token endpoint
-        token_response = await self.post_form(
-            self._session, token_endpoint, self._session_auth_headers, token_body
-        )
-
-        return json_loads(token_response)
 
     async def _login(self) -> bool:
         """Login function.
@@ -381,15 +371,14 @@ class Connection:
             self._session_headers = HEADERS_SESSION.copy()
             self._session_auth_headers = HEADERS_AUTH.copy()
 
-            # Get OpenID configuration for token endpoint
+            # Get OpenID configuration (authorization_endpoint, issuer)
             openid_config = await self.get_openid_config()
-            token_endpoint = openid_config["token_endpoint"]
 
-            # Get authorization code
-            auth_code = await self._get_authorization_code(openid_config)
+            # Get authorization code and hybrid tokens from login flow
+            auth_code, id_token, access_token = await self._get_authorization_code(openid_config)
 
-            # Exchange code for tokens
-            tokens = await self._exchange_code_for_tokens(auth_code, token_endpoint)
+            # Build session tokens from hybrid flow response (no server-side exchange needed)
+            tokens = self._build_session_tokens(auth_code, id_token, access_token)
 
             # Validate token structure
             required_keys = ["access_token", "id_token", "token_type"]
@@ -452,10 +441,7 @@ class Connection:
         self._session_headers.pop("Authorization", None)
 
         if self._session_logged_in:
-            if self._session_headers.get("identity", {}).get("identity_token"):
-                _LOGGER.info("Revoking Identity Access Token")
-
-            if self._session_headers.get("identity", {}).get("refresh_token"):
+            if self._session_tokens.get("identity", {}).get("refresh_token"):
                 _LOGGER.info("Revoking Identity Refresh Token")
                 params = {"token": self._session_tokens["identity"]["refresh_token"]}
                 await self.post(f"{BASE_API}/auth/v1/idk/oidc/revoke", data=params)
@@ -526,7 +512,7 @@ class Connection:
                 return res
         except client_exceptions.ClientResponseError as httperror:
             # Update service status
-            await self.update_service_status(url, httperror.code)
+            await self.update_service_status(url, httperror.status)
             raise httperror from None
         except Exception as error:
             # Update service status

--- a/volkswagencarnet/vw_const.py
+++ b/volkswagencarnet/vw_const.py
@@ -6,8 +6,7 @@ COUNTRY = "DE"
 
 # Data used in communication
 CLIENT_ID = "a24fba63-34b3-4d43-b181-942111e6bda8@apps_vw-dilab_com"
-CLIENT_SCOPE = "openid profile badge cars dealers vin"
-CLIENT_TOKEN_TYPES = "code"
+CLIENT_SCOPE = "openid profile badge cars dealers vin offline_access"
 
 USER_AGENT = "Volkswagen/3.61.0-android/14"
 APP_URI = "weconnect://authenticated"


### PR DESCRIPTION
# Fix VW auth flow: switch to OIDC hybrid flow (code id_token token)

## Background

Around 27 May 2026, Volkswagen changed the CARIAD BFF backend in a way that broke
authentication. PR #331 migrated the OIDC endpoint paths from `/login/v1/idk/` to
`/auth/v1/idk/oidc/` (the correct paths), but login remained broken in two ways:

1. **A critical `TypeError` in `_login`** — `_get_authorization_code` returned a
   `(auth_code, code_verifier)` tuple but `_login` assigned it to a single variable
   and passed it unchanged to `_exchange_code_for_tokens`. This caused a `TypeError`
   on every login attempt, silently caught by the broad `except Exception` handler.

2. **The CARIAD BFF token endpoint now rejects the authorization code exchange** —
   `POST /auth/v1/idk/oidc/token` returns `{"error":"Bad Request"}` regardless of
   whether a PKCE `code_verifier` is included or not. All permutations tried
   (Bearer JWT, inner opaque code, JSON body, form body) failed. The endpoint
   `POST /user-login/login/v1` used in the reverted PR #329 now returns 403.

## Root cause analysis

The auth flow was captured via a MITM proxy on the official Volkswagen iOS app
(v18.7) to understand the exact requests made by a working client.

The proxy showed that identity.vwgroup.io (Auth0) performs the standard
Auth0 Universal Login flow and delivers a **signed JWT** as the authorization code
in the callback URL `weconnect://authenticated?code=<JWT>&state=<state>`.

After extensive testing of every viable token exchange approach against
`/auth/v1/idk/oidc/token`, the root cause became clear: the CARIAD BFF acts as a
**confidential client** to Auth0 and handles the Auth0-side token exchange
server-side using its own credentials. It does not expose a usable public-client
token exchange endpoint for authorization codes.

## Solution

Switch to the **OIDC hybrid flow** (`response_type=code id_token token`).

When Auth0's authorization endpoint is called with this response type, it delivers
`access_token` and `id_token` **directly in the callback URL** (query string /
fragment), alongside the `code`. These Auth0-issued tokens are JWTs that the CARIAD
BFF validates via Auth0's public keys — no separate token exchange step is needed.

This approach was confirmed working against the live API with real credentials and
a real vehicle account (two VINs, full telemetry data retrieved).

## Changes

### `volkswagencarnet/vw_const.py`

- Added `offline_access` to `CLIENT_SCOPE` — confirmed present in the `scp` claim
  of tokens issued by the live Auth0 server; without it no refresh token is issued.
- Removed `CLIENT_TOKEN_TYPES = "code"` — no longer used; response type is now
  hardcoded to `"code id_token token"` where it matters.

### `volkswagencarnet/vw_connection.py`

**`get_authorization_page`**

- Removed unused `code_challenge` parameter (PKCE remnant).
- Removed redundant `try/except` wrapper that only re-raised exceptions.
- Changed `response_type` to `"code id_token token"` (hybrid flow).
- Added `nonce` parameter (required by Auth0 hybrid flow; Auth0 embeds it in the
  returned `id_token`).
- Improved error message when the authorization redirect is missing.

**`_get_authorization_code`**

- Added `action=default` to the login form POST body — required by Auth0 Universal
  Login to distinguish a credential submission from other form actions (e.g.
  "Forgot password"). Without it the login POST can be silently ignored.
- Updated to parse both the query string and the URL fragment from the callback,
  extracting `code`, `id_token`, and `access_token`.
- Returns a `(auth_code, id_token, access_token)` tuple.

**`_exchange_code_for_tokens` → `_build_session_tokens`**

- Renamed to reflect that no server-side token exchange occurs.
- Removed all token exchange logic (form POST, JSON POST, Bearer JWT header
  variants — all returned 400/403 from the CARIAD BFF).
- Now simply packages the hybrid flow tokens into the session dict; retains the
  JWT decode for debug logging only.

**`_login`**

- Fixed the tuple-unpacking bug introduced after PR #331 that caused every login
  attempt to raise `TypeError`.
- Removed `token_endpoint` fetching (no longer needed for the initial login).
- Updated to call `_build_session_tokens`.

**`handle_login_with_password`**

- Removed — was a thin one-liner wrapper around `post_form` with no callers.

**`logout`**

- Fixed pre-existing bug: refresh token revocation checked `_session_headers`
  instead of `_session_tokens` for the token lookup, so revocation never fired.

## Known limitations

**No refresh token — re-login required on expiry.**

The hybrid flow does not return a `refresh_token` (long-lived tokens are never
placed in URLs for security reasons). All alternative paths to obtain one were
tested and failed:

| Approach | Result |
|---|---|
| `POST /auth/v1/idk/oidc/token` (inner opaque code, Bearer JWT) | `400 Bad Request` |
| `POST /auth/v1/idk/oidc/token` (inner code, no Bearer) | `400 Bad Request` |
| `POST /auth/v1/idk/oidc/token` (JWT as `code`) | `400 invalid assertion headers` |
| `POST https://identity.vwgroup.io/oidc/v1/token` (direct Auth0, no PKCE) | `401 access_denied` |
| `POST https://identity.vwgroup.io/oidc/v1/token` (direct Auth0, with PKCE) | `401 access_denied` |
| `POST /user-login/login/v1` (VW-specific endpoint) | `403 Forbidden` |

Auth0 binds the authorization code to the CARIAD BFF as the authorised exchanger;
direct exchanges from the public client are rejected. The CARIAD BFF's own token
exchange endpoint returns 400 for all attempted parameter combinations.

When the `access_token` expires (typically ~2 hours), a full re-login is required.
The `refresh_tokens` method is preserved in place — if VW restores a usable code
exchange path on the BFF, it will work automatically.

## Testing

Verified with a real VW account:

- Login succeeds end-to-end
- All registered VINs are discovered
- Full vehicle telemetry is returned (battery, charging, climate, doors, windows,
  fuel level, trip statistics, maintenance intervals)
- Logout completes without error
